### PR TITLE
feat: LLM service for FreeCAD code generation

### DIFF
--- a/backend/prompts/system_prompt.txt
+++ b/backend/prompts/system_prompt.txt
@@ -1,0 +1,22 @@
+You are a FreeCAD Python code generator. You write Python scripts that run inside FreeCAD's headless mode (freecadcmd).
+
+RULES:
+1. Always start with: import FreeCAD, Part
+2. Create a new document: doc = FreeCAD.newDocument("GPTCAD")
+3. Use the Part workbench for solid modeling (Part.makeBox, Part.makeCylinder, Part.makeSphere, Part.makeCone, Part.makeTorus)
+4. For complex shapes, use boolean operations: .fuse(), .cut(), .common()
+5. For fillets: .makeFillet(), for chamfers: .makeChamfer()
+6. Always add the final shape to the document:
+   obj = doc.addObject("Part::Feature", "Result")
+   obj.Shape = final_shape
+   doc.recompute()
+7. At the end, export the result:
+   Part.export([obj], OUTPUT_PATH)
+8. OUTPUT_PATH will be provided as a variable - do not define it yourself.
+9. Use variables for all dimensions so they're easy to modify.
+10. Add brief comments explaining each modeling step.
+11. NEVER use any GUI or FreeCADGui commands - this runs headless.
+12. NEVER use import FreeCADGui or Gui commands.
+13. Use millimeters as the default unit.
+14. Make sure the shape is valid and watertight.
+15. Return ONLY the Python code, no explanations or markdown fences.

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from openai import AsyncOpenAI
+
+from backend.config import settings
+
+_PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+_client = AsyncOpenAI(
+    base_url=settings.OPENAI_BASE_URL,
+    api_key=settings.OPENAI_API_KEY,
+)
+
+
+def _load_prompt(name: str) -> str:
+    return (_PROMPTS_DIR / name).read_text()
+
+
+async def generate_freecad_code(user_prompt: str, history: list[dict] | None = None) -> str:
+    """Send a user prompt to the LLM and return FreeCAD Python code."""
+    system = _load_prompt("system_prompt.txt")
+    messages: list[dict] = [{"role": "system", "content": system}]
+
+    if history:
+        messages.extend(history)
+
+    messages.append({"role": "user", "content": user_prompt})
+
+    response = await _client.chat.completions.create(
+        model=settings.OPENAI_MODEL,
+        messages=messages,
+        temperature=0.2,
+        max_tokens=4096,
+    )
+
+    code = response.choices[0].message.content.strip()
+
+    # Strip markdown fences if the model wraps them
+    if code.startswith("```"):
+        lines = code.split("\n")
+        # Remove first and last fence lines
+        lines = [l for l in lines if not l.strip().startswith("```")]
+        code = "\n".join(lines)
+
+    return code


### PR DESCRIPTION
## Summary
- Async OpenAI-compatible client using configured LLM gateway endpoint
- System prompt enforcing FreeCAD headless Python code generation rules
- Conversation history support for iterative refinement
- Automatic markdown fence stripping

## Test Plan
- [x] LLM client initializes with configured base URL and API key
- [x] System prompt loaded from file correctly
- [x] Code fence stripping handles wrapped responses

Closes #2

Generated with [Claude Code](https://claude.com/claude-code)