### PR TITLE
feat: FreeCAD runner, mesh converter, and project manager

### DIFF
--- a/backend/services/freecad_runner.py
+++ b/backend/services/freecad_runner.py
@@ -1,0 +1,41 @@
+import asyncio
+import tempfile
+from pathlib import Path
+
+from backend.config import settings
+
+
+async def execute_freecad_script(code: str, project_dir: Path) -> Path:
+    """Execute a FreeCAD Python script and return the path to the output .brep file.
+
+    The code is expected to export to OUTPUT_PATH, which we inject as a variable.
+    """
+    project_dir.mkdir(parents=True, exist_ok=True)
+    output_path = project_dir / "model.brep"
+
+    # Prepend OUTPUT_PATH variable to the user code
+    full_script = f'OUTPUT_PATH = r"{output_path}"\n\n{code}'
+
+    script_path = project_dir / "script.py"
+    script_path.write_text(full_script)
+
+    process = await asyncio.create_subprocess_exec(
+        settings.FREECAD_CMD,
+        str(script_path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(project_dir),
+    )
+
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=60)
+
+    if process.returncode != 0:
+        error_msg = stderr.decode().strip() or stdout.decode().strip()
+        raise RuntimeError(f"FreeCAD execution failed (exit {process.returncode}):\n{error_msg}")
+
+    if not output_path.exists():
+        # Check if FreeCAD wrote any output - sometimes errors go to stdout
+        all_output = stdout.decode() + "\n" + stderr.decode()
+        raise RuntimeError(f"FreeCAD did not produce output file.\n{all_output.strip()}")
+
+    return output_path

--- a/backend/services/mesh_converter.py
+++ b/backend/services/mesh_converter.py
@@ -1,0 +1,55 @@
+import asyncio
+from pathlib import Path
+
+from backend.config import settings
+
+
+async def convert_brep_to_glb(brep_path: Path, output_path: Path) -> Path:
+    """Convert a .brep file to .glb using FreeCAD's mesh export.
+
+    Runs a small FreeCAD script that loads the .brep and exports as mesh.
+    Then converts the mesh to glTF using trimesh.
+    """
+    # First export to STL via FreeCAD, then convert STL to GLB via trimesh
+    stl_path = output_path.with_suffix(".stl")
+
+    convert_script = f'''
+import FreeCAD
+import Part
+import Mesh
+
+shape = Part.read(r"{brep_path}")
+mesh = Mesh.Mesh()
+# Tessellate with 0.1mm tolerance for good quality
+mesh.addFacets(shape.tessellate(0.1))
+mesh.write(r"{stl_path}")
+'''
+
+    script_path = brep_path.parent / "convert.py"
+    script_path.write_text(convert_script)
+
+    process = await asyncio.create_subprocess_exec(
+        settings.FREECAD_CMD,
+        str(script_path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+
+    if not stl_path.exists():
+        # Fallback: try trimesh directly if it can read .brep
+        raise RuntimeError(
+            f"Mesh conversion failed.\n{stderr.decode().strip()}"
+        )
+
+    # Convert STL to GLB using trimesh
+    import trimesh
+    mesh = trimesh.load(str(stl_path))
+    mesh.export(str(output_path), file_type="glb")
+
+    # Cleanup intermediate STL
+    stl_path.unlink(missing_ok=True)
+    script_path.unlink(missing_ok=True)
+
+    return output_path

--- a/backend/services/project_manager.py
+++ b/backend/services/project_manager.py
@@ -1,0 +1,22 @@
+import uuid
+from pathlib import Path
+
+from backend.config import settings
+
+
+def create_project(project_id: str | None = None) -> tuple[str, Path]:
+    """Create a new project directory and return (project_id, project_dir)."""
+    if not project_id:
+        project_id = uuid.uuid4().hex[:12]
+
+    project_dir = settings.STORAGE_DIR / project_id
+    project_dir.mkdir(parents=True, exist_ok=True)
+    return project_id, project_dir
+
+
+def get_project_dir(project_id: str) -> Path:
+    """Get the directory for an existing project."""
+    project_dir = settings.STORAGE_DIR / project_id
+    if not project_dir.exists():
+        raise FileNotFoundError(f"Project {project_id} not found")
+    return project_dir


### PR DESCRIPTION
## Summary
- Async FreeCAD script execution via subprocess with 60s timeout
- Two-stage mesh conversion: .brep -> .stl (FreeCAD) -> .glb (trimesh)
- Project directory manager with UUID-based project IDs

## Test Plan
- [x] FreeCAD runner injects OUTPUT_PATH and executes scripts
- [x] Error handling captures stderr from failed FreeCAD runs
- [x] Project manager creates/retrieves project directories

Closes #3

Generated with [Claude Code](https://claude.com/claude-code)