### PR TITLE
feat: /api/generate endpoint wiring full pipeline

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from backend.config import settings
+from backend.routers import generate
 
 app = FastAPI(title="GPTCAD", version="0.1.0")
 
@@ -19,6 +20,9 @@ settings.STORAGE_DIR.mkdir(parents=True, exist_ok=True)
 
 # Serve generated model files
 app.mount("/storage", StaticFiles(directory=str(settings.STORAGE_DIR)), name="storage")
+
+
+app.include_router(generate.router)
 
 
 @app.get("/api/health")

--- a/backend/routers/generate.py
+++ b/backend/routers/generate.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.services.llm import generate_freecad_code
+from backend.services.freecad_runner import execute_freecad_script
+from backend.services.mesh_converter import convert_brep_to_glb
+from backend.services.project_manager import create_project
+
+router = APIRouter(prefix="/api", tags=["generate"])
+
+
+class GenerateRequest(BaseModel):
+    prompt: str
+    project_id: str | None = None
+
+
+class GenerateResponse(BaseModel):
+    project_id: str
+    model_url: str
+    code: str
+
+
+@router.post("/generate", response_model=GenerateResponse)
+async def generate(req: GenerateRequest):
+    """Generate a CAD model from a natural language prompt."""
+    try:
+        # 1. Generate FreeCAD code via LLM
+        code = await generate_freecad_code(req.prompt)
+
+        # 2. Set up project directory
+        project_id, project_dir = create_project(req.project_id)
+
+        # 3. Execute FreeCAD script
+        brep_path = await execute_freecad_script(code, project_dir)
+
+        # 4. Convert to glTF
+        glb_path = project_dir / "model.glb"
+        await convert_brep_to_glb(brep_path, glb_path)
+
+        # 5. Save the generated code
+        (project_dir / "code.py").write_text(code)
+
+        return GenerateResponse(
+            project_id=project_id,
+            model_url=f"/storage/{project_id}/model.glb",
+            code=code,
+        )
+
+    except RuntimeError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Generation failed: {e}")


### PR DESCRIPTION
## Summary
- `POST /api/generate` accepts a natural language prompt
- Wires the full pipeline: LLM code gen -> FreeCAD execution -> mesh conversion
- Returns `project_id`, `model_url` (.glb), and generated `code`
- Router registered in main.py

## Test Plan
- [x] Router imports and registers without errors
- [x] Endpoint schema validates request/response models
- [x] Error handling returns appropriate HTTP status codes

Closes #4

Generated with [Claude Code](https://claude.com/claude-code)