### PR TITLE
feat: Three-panel resizable layout with top bar and status bar

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,20 +1,64 @@
+import TopBar from './Toolbar/TopBar';
+import StatusBar from './Toolbar/StatusBar';
+import { useResizable } from '../hooks/useResizable';
+
+function ResizeHandle({ onMouseDown }: { onMouseDown: (e: React.MouseEvent) => void }) {
+  return (
+    <div
+      className="w-1 cursor-col-resize bg-border hover:bg-accent transition-colors shrink-0"
+      onMouseDown={onMouseDown}
+    />
+  );
+}
+
 export default function Layout() {
+  const left = useResizable(320, 200, 600, 'left');
+  const right = useResizable(360, 240, 600, 'right');
+
   return (
     <div className="flex flex-col h-screen w-screen bg-bg-primary">
-      {/* Top Bar */}
-      <div className="h-12 flex items-center px-4 border-b border-border bg-bg-panel shrink-0">
-        <span className="text-lg font-bold tracking-tight text-accent">GPTCAD</span>
+      <TopBar />
+
+      <div className="flex-1 flex overflow-hidden">
+        {/* Code Panel (Left) */}
+        <div
+          className="shrink-0 bg-bg-panel border-r border-border flex flex-col"
+          style={{ width: left.width }}
+        >
+          <div className="h-9 flex items-center px-3 border-b border-border">
+            <span className="text-xs font-medium text-text-secondary uppercase tracking-wider">Code</span>
+          </div>
+          <div className="flex-1 flex items-center justify-center text-text-muted text-xs">
+            Code panel
+          </div>
+        </div>
+
+        <ResizeHandle onMouseDown={left.onMouseDown} />
+
+        {/* Viewport (Center) */}
+        <div className="flex-1 relative bg-bg-primary min-w-0">
+          <div className="absolute inset-0 flex items-center justify-center text-text-muted text-sm">
+            3D Viewport
+          </div>
+        </div>
+
+        <ResizeHandle onMouseDown={right.onMouseDown} />
+
+        {/* Prompt Panel (Right) */}
+        <div
+          className="shrink-0 bg-bg-panel border-l border-border flex flex-col"
+          style={{ width: right.width }}
+        >
+          <div className="h-9 flex items-center px-3 border-b border-border">
+            <span className="text-xs font-medium text-text-secondary uppercase tracking-wider">Prompt</span>
+          </div>
+          <div className="flex-1 flex items-center justify-center text-text-muted text-xs">
+            Prompt panel
+          </div>
+        </div>
       </div>
 
-      {/* Main Content - placeholder */}
-      <div className="flex-1 flex items-center justify-center text-text-secondary">
-        <span className="text-sm">Loading panels...</span>
-      </div>
-
-      {/* Status Bar */}
-      <div className="h-7 flex items-center px-4 border-t border-border bg-bg-panel text-xs text-text-muted shrink-0">
-        <span>Ready</span>
-      </div>
+      <StatusBar />
     </div>
-  )
+  );
 }

--- a/frontend/src/components/Toolbar/StatusBar.tsx
+++ b/frontend/src/components/Toolbar/StatusBar.tsx
@@ -1,0 +1,32 @@
+import { useAppStore } from '../../stores/appStore';
+
+export default function StatusBar() {
+  const isGenerating = useAppStore((s) => s.isGenerating);
+  const error = useAppStore((s) => s.error);
+
+  return (
+    <div className="h-7 flex items-center justify-between px-4 border-t border-border bg-bg-panel text-xs shrink-0">
+      <div className="flex items-center gap-2">
+        {isGenerating ? (
+          <>
+            <div className="w-2 h-2 rounded-full bg-warning animate-pulse" />
+            <span className="text-warning">Generating...</span>
+          </>
+        ) : error ? (
+          <>
+            <div className="w-2 h-2 rounded-full bg-error" />
+            <span className="text-error">Error</span>
+          </>
+        ) : (
+          <>
+            <div className="w-2 h-2 rounded-full bg-success" />
+            <span className="text-text-muted">Ready</span>
+          </>
+        )}
+      </div>
+      <div className="text-text-muted">
+        GPTCAD v0.1.0
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Toolbar/TopBar.tsx
+++ b/frontend/src/components/Toolbar/TopBar.tsx
@@ -1,0 +1,32 @@
+import { Download, Settings, FolderOpen } from 'lucide-react';
+
+export default function TopBar() {
+  return (
+    <div className="h-12 flex items-center justify-between px-4 border-b border-border bg-bg-panel shrink-0">
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-md bg-accent flex items-center justify-center">
+            <span className="text-white font-bold text-xs">G</span>
+          </div>
+          <span className="text-base font-bold tracking-tight text-text-primary">
+            GPTCAD
+          </span>
+        </div>
+        <div className="w-px h-5 bg-border mx-1" />
+        <span className="text-sm text-text-secondary">Untitled Project</span>
+      </div>
+
+      <div className="flex items-center gap-1">
+        <button className="p-2 rounded-md hover:bg-bg-elevated text-text-secondary hover:text-text-primary transition-colors">
+          <FolderOpen size={16} />
+        </button>
+        <button className="p-2 rounded-md hover:bg-bg-elevated text-text-secondary hover:text-text-primary transition-colors">
+          <Download size={16} />
+        </button>
+        <button className="p-2 rounded-md hover:bg-bg-elevated text-text-secondary hover:text-text-primary transition-colors">
+          <Settings size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useResizable.ts
+++ b/frontend/src/hooks/useResizable.ts
@@ -1,0 +1,38 @@
+import { useCallback, useRef, useState } from 'react';
+
+export function useResizable(initialWidth: number, min: number, max: number, direction: 'left' | 'right') {
+  const [width, setWidth] = useState(initialWidth);
+  const dragging = useRef(false);
+  const startX = useRef(0);
+  const startWidth = useRef(0);
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    dragging.current = true;
+    startX.current = e.clientX;
+    startWidth.current = width;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!dragging.current) return;
+      const delta = ev.clientX - startX.current;
+      const newWidth = direction === 'left'
+        ? startWidth.current + delta
+        : startWidth.current - delta;
+      setWidth(Math.max(min, Math.min(max, newWidth)));
+    };
+
+    const onMouseUp = () => {
+      dragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, [width, min, max, direction]);
+
+  return { width, onMouseDown };
+}


### PR DESCRIPTION
## Summary
- Three-panel layout: Code (left) | 3D Viewport (center) | Prompt (right)
- Drag-to-resize handles with min/max constraints
- TopBar with GPTCAD logo, project name, and action buttons (open, export, settings)
- StatusBar with live generation status indicator (ready/generating/error)
- `useResizable` hook for panel resize logic

## Test Plan
- [x] Three panels render with correct proportions
- [x] Drag handles resize panels within bounds
- [x] TopBar and StatusBar display correctly
- [x] TypeScript compiles cleanly

Closes #6

Generated with [Claude Code](https://claude.com/claude-code)