### PR TITLE
feat: Premium 3D viewport with PBR rendering and studio lighting

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import TopBar from './Toolbar/TopBar';
 import StatusBar from './Toolbar/StatusBar';
+import Viewport from './Viewport/Viewport';
 import { useResizable } from '../hooks/useResizable';
 
 function ResizeHandle({ onMouseDown }: { onMouseDown: (e: React.MouseEvent) => void }) {
@@ -37,9 +38,7 @@ export default function Layout() {
 
         {/* Viewport (Center) */}
         <div className="flex-1 relative bg-bg-primary min-w-0">
-          <div className="absolute inset-0 flex items-center justify-center text-text-muted text-sm">
-            3D Viewport
-          </div>
+          <Viewport />
         </div>
 
         <ResizeHandle onMouseDown={right.onMouseDown} />

--- a/frontend/src/components/Viewport/InfiniteGrid.tsx
+++ b/frontend/src/components/Viewport/InfiniteGrid.tsx
@@ -1,0 +1,19 @@
+import { Grid } from '@react-three/drei';
+
+export default function InfiniteGrid() {
+  return (
+    <Grid
+      position={[0, -0.01, 0]}
+      args={[100, 100]}
+      cellSize={1}
+      cellThickness={0.5}
+      cellColor="#1e1e2e"
+      sectionSize={10}
+      sectionThickness={1}
+      sectionColor="#2a2a3e"
+      fadeDistance={60}
+      fadeStrength={1.5}
+      infiniteGrid
+    />
+  );
+}

--- a/frontend/src/components/Viewport/ModelRenderer.tsx
+++ b/frontend/src/components/Viewport/ModelRenderer.tsx
@@ -1,0 +1,58 @@
+import { useGLTF, Center } from '@react-three/drei';
+import { useEffect, useMemo } from 'react';
+import * as THREE from 'three';
+
+interface ModelRendererProps {
+  url: string;
+}
+
+export default function ModelRenderer({ url }: ModelRendererProps) {
+  const { scene } = useGLTF(url);
+
+  const cloned = useMemo(() => {
+    const clone = scene.clone(true);
+
+    // Apply premium PBR material to all meshes
+    const material = new THREE.MeshStandardMaterial({
+      color: '#b0bec5',
+      metalness: 0.6,
+      roughness: 0.35,
+      envMapIntensity: 0.8,
+    });
+
+    clone.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        child.material = material;
+        child.castShadow = true;
+        child.receiveShadow = true;
+
+        // Compute smooth normals if not present
+        if (!child.geometry.attributes.normal) {
+          child.geometry.computeVertexNormals();
+        }
+      }
+    });
+
+    return clone;
+  }, [scene]);
+
+  useEffect(() => {
+    return () => {
+      // Cleanup on unmount
+      cloned.traverse((child) => {
+        if (child instanceof THREE.Mesh) {
+          child.geometry.dispose();
+          if (child.material instanceof THREE.Material) {
+            child.material.dispose();
+          }
+        }
+      });
+    };
+  }, [cloned]);
+
+  return (
+    <Center>
+      <primitive object={cloned} />
+    </Center>
+  );
+}

--- a/frontend/src/components/Viewport/SceneSetup.tsx
+++ b/frontend/src/components/Viewport/SceneSetup.tsx
@@ -1,0 +1,48 @@
+import { useThree } from '@react-three/fiber';
+import { useEffect } from 'react';
+import * as THREE from 'three';
+
+export default function SceneSetup() {
+  const { scene } = useThree();
+
+  useEffect(() => {
+    // Gradient background
+    scene.background = new THREE.Color('#13131f');
+  }, [scene]);
+
+  return (
+    <>
+      {/* Key light */}
+      <directionalLight
+        position={[8, 12, 10]}
+        intensity={1.5}
+        color="#ffffff"
+        castShadow
+        shadow-mapSize={[2048, 2048]}
+        shadow-bias={-0.0001}
+      />
+
+      {/* Fill light */}
+      <directionalLight
+        position={[-5, 6, -8]}
+        intensity={0.6}
+        color="#a0c4ff"
+      />
+
+      {/* Rim light */}
+      <directionalLight
+        position={[0, -4, -10]}
+        intensity={0.3}
+        color="#c084fc"
+      />
+
+      {/* Ambient */}
+      <ambientLight intensity={0.35} color="#e8e0ff" />
+
+      {/* Hemisphere light for subtle sky/ground coloring */}
+      <hemisphereLight
+        args={['#7c8aaa', '#3a3a4a', 0.4]}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/Viewport/ViewCube.tsx
+++ b/frontend/src/components/Viewport/ViewCube.tsx
@@ -1,0 +1,13 @@
+import { useThree } from '@react-three/fiber';
+import { GizmoHelper, GizmoViewport } from '@react-three/drei';
+
+export default function ViewCube() {
+  return (
+    <GizmoHelper alignment="top-right" margin={[64, 64]}>
+      <GizmoViewport
+        axisColors={['#ef4444', '#22c55e', '#3b82f6']}
+        labelColor="white"
+      />
+    </GizmoHelper>
+  );
+}

--- a/frontend/src/components/Viewport/Viewport.tsx
+++ b/frontend/src/components/Viewport/Viewport.tsx
@@ -1,0 +1,55 @@
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, Environment } from '@react-three/drei';
+import { Suspense } from 'react';
+import SceneSetup from './SceneSetup';
+import InfiniteGrid from './InfiniteGrid';
+import ModelRenderer from './ModelRenderer';
+import ViewCube from './ViewCube';
+import { useAppStore } from '../../stores/appStore';
+
+function LoadingFallback() {
+  return (
+    <mesh>
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color="#2a2a3e" wireframe />
+    </mesh>
+  );
+}
+
+export default function Viewport() {
+  const modelUrl = useAppStore((s) => s.modelUrl);
+
+  return (
+    <Canvas
+      shadows
+      camera={{ position: [6, 4, 8], fov: 45, near: 0.1, far: 1000 }}
+      gl={{
+        antialias: true,
+        toneMapping: 3, // ACESFilmicToneMapping
+        toneMappingExposure: 1.1,
+      }}
+      style={{ background: '#13131f' }}
+    >
+      <SceneSetup />
+
+      <Environment preset="studio" environmentIntensity={0.4} />
+
+      <InfiniteGrid />
+
+      <Suspense fallback={<LoadingFallback />}>
+        {modelUrl && <ModelRenderer url={modelUrl} />}
+      </Suspense>
+
+      <OrbitControls
+        makeDefault
+        enableDamping
+        dampingFactor={0.08}
+        minDistance={1}
+        maxDistance={200}
+        target={[0, 0, 0]}
+      />
+
+      <ViewCube />
+    </Canvas>
+  );
+}


### PR DESCRIPTION
## Summary
- Three.js Canvas with ACES filmic tone mapping and MSAA
- Studio HDRI environment for realistic reflections
- 5-light setup: key (white), fill (blue), rim (purple), ambient, hemisphere
- Infinite grid with section lines and distance fade
- glTF model loader applying PBR material (metallic: 0.6, roughness: 0.35)
- View cube (GizmoHelper) for orientation navigation
- Orbit controls with damping, min/max distance limits
- Shadow casting and receiving on model meshes

## Test Plan
- [x] Canvas renders with dark background, grid, and lighting
- [x] Orbit/pan/zoom controls respond to mouse input
- [x] View cube renders in top-right corner
- [x] Model loads when modelUrl is set in store
- [x] TypeScript compiles cleanly

Closes #7

Generated with [Claude Code](https://claude.com/claude-code)