### PR TITLE
feat: Prompt panel with chat history and code panel with Monaco editor

### DIFF
--- a/frontend/src/components/CodePanel/CodePanel.tsx
+++ b/frontend/src/components/CodePanel/CodePanel.tsx
@@ -1,0 +1,74 @@
+import Editor from '@monaco-editor/react';
+import { Code2, Copy, Check } from 'lucide-react';
+import { useState } from 'react';
+import { useAppStore } from '../../stores/appStore';
+
+export default function CodePanel() {
+  const code = useAppStore((s) => s.code);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    if (!code) return;
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="h-9 flex items-center justify-between px-3 border-b border-border shrink-0">
+        <div className="flex items-center gap-1.5">
+          <Code2 size={13} className="text-text-muted" />
+          <span className="text-xs font-medium text-text-secondary uppercase tracking-wider">
+            Generated Code
+          </span>
+        </div>
+        {code && (
+          <button
+            onClick={handleCopy}
+            className="p-1 rounded hover:bg-bg-elevated text-text-muted hover:text-text-primary transition-colors"
+            title="Copy code"
+          >
+            {copied ? <Check size={13} className="text-success" /> : <Copy size={13} />}
+          </button>
+        )}
+      </div>
+
+      {/* Editor */}
+      <div className="flex-1 min-h-0">
+        {code ? (
+          <Editor
+            language="python"
+            value={code}
+            theme="vs-dark"
+            options={{
+              readOnly: true,
+              minimap: { enabled: false },
+              fontSize: 12,
+              fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+              lineNumbers: 'on',
+              scrollBeyondLastLine: false,
+              wordWrap: 'on',
+              padding: { top: 8 },
+              renderLineHighlight: 'none',
+              overviewRulerBorder: false,
+              hideCursorInOverviewRuler: true,
+              scrollbar: {
+                verticalScrollbarSize: 6,
+                horizontalScrollbarSize: 6,
+              },
+            }}
+          />
+        ) : (
+          <div className="h-full flex flex-col items-center justify-center text-text-muted gap-2 px-6">
+            <Code2 size={28} strokeWidth={1.5} className="opacity-40" />
+            <p className="text-xs text-center leading-relaxed">
+              Generated FreeCAD code will appear here when you submit a prompt
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,8 @@
 import TopBar from './Toolbar/TopBar';
 import StatusBar from './Toolbar/StatusBar';
 import Viewport from './Viewport/Viewport';
+import CodePanel from './CodePanel/CodePanel';
+import PromptPanel from './PromptPanel/PromptPanel';
 import { useResizable } from '../hooks/useResizable';
 
 function ResizeHandle({ onMouseDown }: { onMouseDown: (e: React.MouseEvent) => void }) {
@@ -23,15 +25,10 @@ export default function Layout() {
       <div className="flex-1 flex overflow-hidden">
         {/* Code Panel (Left) */}
         <div
-          className="shrink-0 bg-bg-panel border-r border-border flex flex-col"
+          className="shrink-0 bg-bg-panel flex flex-col overflow-hidden"
           style={{ width: left.width }}
         >
-          <div className="h-9 flex items-center px-3 border-b border-border">
-            <span className="text-xs font-medium text-text-secondary uppercase tracking-wider">Code</span>
-          </div>
-          <div className="flex-1 flex items-center justify-center text-text-muted text-xs">
-            Code panel
-          </div>
+          <CodePanel />
         </div>
 
         <ResizeHandle onMouseDown={left.onMouseDown} />
@@ -45,15 +42,10 @@ export default function Layout() {
 
         {/* Prompt Panel (Right) */}
         <div
-          className="shrink-0 bg-bg-panel border-l border-border flex flex-col"
+          className="shrink-0 bg-bg-panel flex flex-col overflow-hidden"
           style={{ width: right.width }}
         >
-          <div className="h-9 flex items-center px-3 border-b border-border">
-            <span className="text-xs font-medium text-text-secondary uppercase tracking-wider">Prompt</span>
-          </div>
-          <div className="flex-1 flex items-center justify-center text-text-muted text-xs">
-            Prompt panel
-          </div>
+          <PromptPanel />
         </div>
       </div>
 

--- a/frontend/src/components/PromptPanel/ChatHistory.tsx
+++ b/frontend/src/components/PromptPanel/ChatHistory.tsx
@@ -1,0 +1,57 @@
+import { useRef, useEffect } from 'react';
+import { useAppStore } from '../../stores/appStore';
+import { Bot, User } from 'lucide-react';
+
+export default function ChatHistory() {
+  const messages = useAppStore((s) => s.messages);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+  }, [messages]);
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center text-text-muted gap-3 px-6">
+        <div className="w-12 h-12 rounded-xl bg-bg-elevated flex items-center justify-center">
+          <Bot size={24} strokeWidth={1.5} className="opacity-50" />
+        </div>
+        <div className="text-center">
+          <p className="text-xs font-medium text-text-secondary mb-1">Start designing</p>
+          <p className="text-xs leading-relaxed">
+            Describe the 3D model you want to create and GPTCAD will generate it for you
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={scrollRef} className="flex-1 overflow-y-auto px-3 py-3 space-y-3">
+      {messages.map((msg) => (
+        <div key={msg.id} className="flex gap-2">
+          <div className={`w-6 h-6 rounded-md flex items-center justify-center shrink-0 mt-0.5 ${
+            msg.role === 'user' ? 'bg-accent/20' : 'bg-bg-elevated'
+          }`}>
+            {msg.role === 'user' ? (
+              <User size={12} className="text-accent" />
+            ) : (
+              <Bot size={12} className="text-text-secondary" />
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-text-primary leading-relaxed whitespace-pre-wrap break-words">
+              {msg.content}
+            </p>
+            {msg.role === 'assistant' && msg.model_url && (
+              <div className="mt-1.5 text-xs text-success flex items-center gap-1">
+                <div className="w-1.5 h-1.5 rounded-full bg-success" />
+                Model generated
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/PromptPanel/PromptInput.tsx
+++ b/frontend/src/components/PromptPanel/PromptInput.tsx
@@ -1,0 +1,107 @@
+import { useState, useRef, useCallback } from 'react';
+import { Send, Loader2 } from 'lucide-react';
+import { useAppStore } from '../../stores/appStore';
+import { generateModel } from '../../api/client';
+import type { ChatMessage } from '../../types';
+
+export default function PromptInput() {
+  const [input, setInput] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const isGenerating = useAppStore((s) => s.isGenerating);
+  const setGenerating = useAppStore((s) => s.setGenerating);
+  const setModelUrl = useAppStore((s) => s.setModelUrl);
+  const setCode = useAppStore((s) => s.setCode);
+  const setProjectId = useAppStore((s) => s.setProjectId);
+  const addMessage = useAppStore((s) => s.addMessage);
+  const setError = useAppStore((s) => s.setError);
+  const projectId = useAppStore((s) => s.projectId);
+
+  const handleSend = useCallback(async () => {
+    const prompt = input.trim();
+    if (!prompt || isGenerating) return;
+
+    setInput('');
+    setError(null);
+
+    // Add user message
+    const userMsg: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: prompt,
+      timestamp: Date.now(),
+    };
+    addMessage(userMsg);
+
+    setGenerating(true);
+
+    try {
+      const result = await generateModel({ prompt, project_id: projectId ?? undefined });
+
+      setProjectId(result.project_id);
+      setModelUrl(result.model_url);
+      setCode(result.code);
+
+      // Add assistant message
+      const assistantMsg: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: 'assistant',
+        content: 'Model generated successfully.',
+        code: result.code,
+        model_url: result.model_url,
+        timestamp: Date.now(),
+      };
+      addMessage(assistantMsg);
+    } catch (err: any) {
+      const errorMsg = err.response?.data?.detail || err.message || 'Generation failed';
+      setError(errorMsg);
+
+      addMessage({
+        id: crypto.randomUUID(),
+        role: 'assistant',
+        content: `Error: ${errorMsg}`,
+        timestamp: Date.now(),
+      });
+    } finally {
+      setGenerating(false);
+    }
+  }, [input, isGenerating, projectId, setGenerating, setModelUrl, setCode, setProjectId, addMessage, setError]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="p-3 border-t border-border">
+      <div className="flex gap-2 items-end">
+        <textarea
+          ref={textareaRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Describe a 3D model..."
+          rows={2}
+          disabled={isGenerating}
+          className="flex-1 bg-bg-elevated border border-border rounded-lg px-3 py-2 text-xs text-text-primary placeholder-text-muted resize-none focus:outline-none focus:border-accent transition-colors disabled:opacity-50"
+        />
+        <button
+          onClick={handleSend}
+          disabled={!input.trim() || isGenerating}
+          className="p-2.5 bg-accent hover:bg-accent-hover rounded-lg text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
+        >
+          {isGenerating ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : (
+            <Send size={14} />
+          )}
+        </button>
+      </div>
+      <p className="text-[10px] text-text-muted mt-1.5 px-0.5">
+        Enter to send, Shift+Enter for new line
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/PromptPanel/PromptPanel.tsx
+++ b/frontend/src/components/PromptPanel/PromptPanel.tsx
@@ -1,0 +1,25 @@
+import { MessageSquare } from 'lucide-react';
+import ChatHistory from './ChatHistory';
+import PromptInput from './PromptInput';
+
+export default function PromptPanel() {
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="h-9 flex items-center px-3 border-b border-border shrink-0">
+        <div className="flex items-center gap-1.5">
+          <MessageSquare size={13} className="text-text-muted" />
+          <span className="text-xs font-medium text-text-secondary uppercase tracking-wider">
+            Prompt
+          </span>
+        </div>
+      </div>
+
+      {/* Chat History */}
+      <ChatHistory />
+
+      {/* Input */}
+      <PromptInput />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **CodePanel**: Monaco editor with Python syntax highlighting, copy-to-clipboard, read-only mode, JetBrains Mono font, empty state placeholder
- **PromptPanel**: Chat-style UI with user/assistant bubbles, auto-scroll, onboarding empty state
- **PromptInput**: Textarea with Enter-to-send, Shift+Enter for newlines, loading spinner, wired to `POST /api/generate`
- **Layout** updated to render real CodePanel and PromptPanel components

## Test Plan
- [x] Monaco editor renders Python code with syntax highlighting
- [x] Copy button copies code to clipboard
- [x] Chat history auto-scrolls on new messages
- [x] Prompt input sends on Enter, newline on Shift+Enter
- [x] Loading state disables input during generation
- [x] TypeScript compiles cleanly

Closes #8

Generated with [Claude Code](https://claude.com/claude-code)