### PR TITLE
feat: End-to-end integration with dev tooling and fixes

### DIFF
--- a/backend/services/mesh_converter.py
+++ b/backend/services/mesh_converter.py
@@ -5,24 +5,46 @@ from backend.config import settings
 
 
 async def convert_brep_to_glb(brep_path: Path, output_path: Path) -> Path:
-    """Convert a .brep file to .glb using FreeCAD's mesh export.
+    """Convert a .brep file to .glb using FreeCAD's mesh export + trimesh.
 
-    Runs a small FreeCAD script that loads the .brep and exports as mesh.
-    Then converts the mesh to glTF using trimesh.
+    Two-stage pipeline:
+    1. FreeCAD reads .brep shape and exports triangulated .stl
+    2. trimesh converts .stl to .glb (binary glTF)
     """
-    # First export to STL via FreeCAD, then convert STL to GLB via trimesh
     stl_path = output_path.with_suffix(".stl")
 
     convert_script = f'''
+import sys
 import FreeCAD
 import Part
+import MeshPart
 import Mesh
 
-shape = Part.read(r"{brep_path}")
-mesh = Mesh.Mesh()
-# Tessellate with 0.1mm tolerance for good quality
-mesh.addFacets(shape.tessellate(0.1))
-mesh.write(r"{stl_path}")
+try:
+    shape = Part.read(r"{brep_path}")
+
+    # Tessellate using MeshPart for better quality
+    mesh_data = MeshPart.meshFromShape(
+        Shape=shape,
+        LinearDeflection=0.1,
+        AngularDeflection=0.5,
+        Relative=False
+    )
+    mesh_data.write(r"{stl_path}")
+    print("MESH_EXPORT_OK")
+except Exception as e:
+    # Fallback: use basic Mesh tessellation
+    try:
+        shape = Part.read(r"{brep_path}")
+        doc = FreeCAD.newDocument("Convert")
+        obj = doc.addObject("Part::Feature", "Shape")
+        obj.Shape = shape
+        doc.recompute()
+        Mesh.export([obj], r"{stl_path}")
+        print("MESH_EXPORT_OK_FALLBACK")
+    except Exception as e2:
+        print(f"MESH_EXPORT_FAILED: {{e2}}", file=sys.stderr)
+        sys.exit(1)
 '''
 
     script_path = brep_path.parent / "convert.py"
@@ -38,9 +60,8 @@ mesh.write(r"{stl_path}")
     stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
 
     if not stl_path.exists():
-        # Fallback: try trimesh directly if it can read .brep
         raise RuntimeError(
-            f"Mesh conversion failed.\n{stderr.decode().strip()}"
+            f"Mesh conversion failed.\nstdout: {stdout.decode().strip()}\nstderr: {stderr.decode().strip()}"
         )
 
     # Convert STL to GLB using trimesh
@@ -48,7 +69,7 @@ mesh.write(r"{stl_path}")
     mesh = trimesh.load(str(stl_path))
     mesh.export(str(output_path), file_type="glb")
 
-    # Cleanup intermediate STL
+    # Cleanup intermediate files
     stl_path.unlink(missing_ok=True)
     script_path.unlink(missing_ok=True)
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# GPTCAD Development Server
+# Starts both backend (FastAPI) and frontend (Vite) concurrently
+
+set -e
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Starting GPTCAD development servers..."
+
+# Start backend
+echo "[Backend] Starting FastAPI on port 8080..."
+(
+  cd "$ROOT_DIR"
+  source .venv/bin/activate 2>/dev/null || true
+  uvicorn backend.main:app --host 0.0.0.0 --port 8080 --reload
+) &
+BACKEND_PID=$!
+
+# Start frontend
+echo "[Frontend] Starting Vite on port 5175..."
+(
+  cd "$ROOT_DIR/frontend"
+  npm run dev
+) &
+FRONTEND_PID=$!
+
+# Handle cleanup on exit
+cleanup() {
+  echo ""
+  echo "Shutting down..."
+  kill $BACKEND_PID $FRONTEND_PID 2>/dev/null
+  wait $BACKEND_PID $FRONTEND_PID 2>/dev/null
+  echo "Done."
+}
+trap cleanup EXIT INT TERM
+
+echo ""
+echo "  Backend:  http://localhost:8080"
+echo "  Frontend: http://localhost:5175"
+echo ""
+echo "Press Ctrl+C to stop both servers."
+echo ""
+
+wait

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,9 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>GPTCAD</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#6366f1"/>
+  <text x="16" y="22" text-anchor="middle" font-family="system-ui" font-weight="700" font-size="16" fill="white">G</text>
+</svg>

--- a/frontend/src/components/Viewport/ViewCube.tsx
+++ b/frontend/src/components/Viewport/ViewCube.tsx
@@ -1,4 +1,3 @@
-import { useThree } from '@react-three/fiber';
 import { GizmoHelper, GizmoViewport } from '@react-three/drei';
 
 export default function ViewCube() {


### PR DESCRIPTION
## Summary
- Improved mesh converter: MeshPart tessellation with fallback to basic Mesh export
- Fixed unused import in ViewCube.tsx that caused production build failure
- Updated `index.html` with GPTCAD title, branded favicon, Inter + JetBrains Mono fonts
- Added `dev.sh` script to start backend (port 8080) + frontend (port 5175) concurrently
- Full pipeline verified: health endpoint accessible, frontend builds cleanly

## Test Plan
- [x] Backend health endpoint returns 200
- [x] Frontend production build succeeds (`npm run build`)
- [x] `dev.sh` starts both servers
- [x] Vite proxy correctly forwards `/api` and `/storage` to backend
- [x] TypeScript compiles with no errors

Closes #9

Generated with [Claude Code](https://claude.com/claude-code)