### PR TITLE
feat: /api/iterate endpoint with version storage

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from backend.config import settings
-from backend.routers import generate
+from backend.routers import generate, iterate
 
 app = FastAPI(title="GPTCAD", version="0.1.0")
 
@@ -23,6 +23,7 @@ app.mount("/storage", StaticFiles(directory=str(settings.STORAGE_DIR)), name="st
 
 
 app.include_router(generate.router)
+app.include_router(iterate.router)
 
 
 @app.get("/api/health")

--- a/backend/prompts/iterate_prompt.txt
+++ b/backend/prompts/iterate_prompt.txt
@@ -1,0 +1,16 @@
+You are a FreeCAD Python code modifier. You receive existing FreeCAD Python code and a user instruction to modify it.
+
+RULES:
+1. You will receive the CURRENT working FreeCAD Python code and a modification instruction.
+2. Return the COMPLETE modified Python script - not a diff or partial code.
+3. Preserve the overall structure: imports, document creation, and export.
+4. Keep all existing features unless the user explicitly asks to remove them.
+5. Use the same variable naming conventions as the original code.
+6. The script must still export to OUTPUT_PATH (already defined as a variable).
+7. Maintain parametric dimensions as variables.
+8. Add brief comments for new/modified sections.
+9. NEVER use GUI or FreeCADGui commands - this runs headless.
+10. NEVER import FreeCADGui.
+11. Use millimeters as the default unit.
+12. Make sure the final shape is valid and watertight.
+13. Return ONLY the Python code, no explanations or markdown fences.

--- a/backend/routers/generate.py
+++ b/backend/routers/generate.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from backend.services.llm import generate_freecad_code
 from backend.services.freecad_runner import execute_freecad_script
 from backend.services.mesh_converter import convert_brep_to_glb
-from backend.services.project_manager import create_project
+from backend.services.project_manager import create_project, save_version
 
 router = APIRouter(prefix="/api", tags=["generate"])
 
@@ -18,6 +18,7 @@ class GenerateResponse(BaseModel):
     project_id: str
     model_url: str
     code: str
+    version: int
 
 
 @router.post("/generate", response_model=GenerateResponse)
@@ -37,13 +38,16 @@ async def generate(req: GenerateRequest):
         glb_path = project_dir / "model.glb"
         await convert_brep_to_glb(brep_path, glb_path)
 
-        # 5. Save the generated code
+        # 5. Save as version 1 and current code
+        model_url = f"/storage/{project_id}/model.glb"
+        save_version(project_id, 1, code, model_url)
         (project_dir / "code.py").write_text(code)
 
         return GenerateResponse(
             project_id=project_id,
-            model_url=f"/storage/{project_id}/model.glb",
+            model_url=model_url,
             code=code,
+            version=1,
         )
 
     except RuntimeError as e:

--- a/backend/routers/iterate.py
+++ b/backend/routers/iterate.py
@@ -1,0 +1,79 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.services.llm import generate_freecad_code
+from backend.services.freecad_runner import execute_freecad_script
+from backend.services.mesh_converter import convert_brep_to_glb
+from backend.services.project_manager import (
+    create_project,
+    get_next_version,
+    save_version,
+)
+
+router = APIRouter(prefix="/api", tags=["iterate"])
+
+
+class IterateRequest(BaseModel):
+    project_id: str
+    instruction: str
+    current_code: str
+    history: list[dict] | None = None
+
+
+class IterateResponse(BaseModel):
+    project_id: str
+    model_url: str
+    code: str
+    version: int
+
+
+@router.post("/iterate", response_model=IterateResponse)
+async def iterate(req: IterateRequest):
+    """Refine an existing CAD model with a follow-up instruction."""
+    try:
+        # Build conversation history for iteration context
+        history = []
+        if req.history:
+            history.extend(req.history)
+
+        # Add the current code as context
+        iteration_prompt = (
+            f"Here is the current FreeCAD Python code:\n\n```python\n{req.current_code}\n```\n\n"
+            f"Modify it according to this instruction: {req.instruction}"
+        )
+
+        code = await generate_freecad_code(
+            iteration_prompt,
+            history=history,
+            system_prompt_name="iterate_prompt.txt",
+        )
+
+        # Set up project directory
+        project_id, project_dir = create_project(req.project_id)
+
+        # Execute FreeCAD script
+        brep_path = await execute_freecad_script(code, project_dir)
+
+        # Convert to glTF
+        glb_path = project_dir / "model.glb"
+        await convert_brep_to_glb(brep_path, glb_path)
+
+        # Save version
+        version = get_next_version(project_id)
+        model_url = f"/storage/{project_id}/model.glb"
+        save_version(project_id, version, code, model_url)
+
+        # Also save as current code
+        (project_dir / "code.py").write_text(code)
+
+        return IterateResponse(
+            project_id=project_id,
+            model_url=model_url,
+            code=code,
+            version=version,
+        )
+
+    except RuntimeError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Iteration failed: {e}")

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -16,9 +16,13 @@ def _load_prompt(name: str) -> str:
     return (_PROMPTS_DIR / name).read_text()
 
 
-async def generate_freecad_code(user_prompt: str, history: list[dict] | None = None) -> str:
+async def generate_freecad_code(
+    user_prompt: str,
+    history: list[dict] | None = None,
+    system_prompt_name: str = "system_prompt.txt",
+) -> str:
     """Send a user prompt to the LLM and return FreeCAD Python code."""
-    system = _load_prompt("system_prompt.txt")
+    system = _load_prompt(system_prompt_name)
     messages: list[dict] = [{"role": "system", "content": system}]
 
     if history:

--- a/backend/services/project_manager.py
+++ b/backend/services/project_manager.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from pathlib import Path
 
@@ -20,3 +21,66 @@ def get_project_dir(project_id: str) -> Path:
     if not project_dir.exists():
         raise FileNotFoundError(f"Project {project_id} not found")
     return project_dir
+
+
+def get_next_version(project_id: str) -> int:
+    """Return the next version number for a project."""
+    project_dir = settings.STORAGE_DIR / project_id
+    if not project_dir.exists():
+        return 1
+    existing = sorted(
+        [d.name for d in project_dir.iterdir() if d.is_dir() and d.name.startswith("v")]
+    )
+    if not existing:
+        return 1
+    last = int(existing[-1][1:])
+    return last + 1
+
+
+def save_version(project_id: str, version: int, code: str, model_url: str) -> Path:
+    """Save a version snapshot: code + metadata to v{n}/ subdirectory."""
+    project_dir = settings.STORAGE_DIR / project_id
+    version_dir = project_dir / f"v{version}"
+    version_dir.mkdir(parents=True, exist_ok=True)
+
+    # Save code
+    (version_dir / "code.py").write_text(code)
+
+    # Save metadata
+    meta = {"version": version, "model_url": model_url}
+    (version_dir / "meta.json").write_text(json.dumps(meta))
+
+    return version_dir
+
+
+def list_versions(project_id: str) -> list[dict]:
+    """List all versions for a project."""
+    project_dir = settings.STORAGE_DIR / project_id
+    if not project_dir.exists():
+        return []
+
+    versions = []
+    for d in sorted(project_dir.iterdir()):
+        if d.is_dir() and d.name.startswith("v"):
+            meta_path = d / "meta.json"
+            if meta_path.exists():
+                meta = json.loads(meta_path.read_text())
+                code_path = d / "code.py"
+                if code_path.exists():
+                    meta["code"] = code_path.read_text()
+                versions.append(meta)
+    return versions
+
+
+def get_version(project_id: str, version: int) -> dict:
+    """Get a specific version's code and metadata."""
+    project_dir = settings.STORAGE_DIR / project_id
+    version_dir = project_dir / f"v{version}"
+    if not version_dir.exists():
+        raise FileNotFoundError(f"Version {version} not found for project {project_id}")
+
+    meta = json.loads((version_dir / "meta.json").read_text())
+    code_path = version_dir / "code.py"
+    if code_path.exists():
+        meta["code"] = code_path.read_text()
+    return meta


### PR DESCRIPTION
## Summary
- `POST /api/iterate` accepts project_id, instruction, current_code, and conversation history
- Dedicated `iterate_prompt.txt` system prompt for code modification context
- Version storage: each iteration saves code + metadata to `v{n}/` subdirectory
- `generate` endpoint now also saves as version 1
- Both endpoints return `version` number in response
- LLM service supports configurable system prompt

## Test Plan
- [x] All new imports resolve cleanly
- [x] Iterate router registered in main.py
- [x] Version numbering auto-increments
- [x] Project manager CRUD operations work

Closes #19

Generated with [Claude Code](https://claude.com/claude-code)