### PR TITLE
feat: Frontend iteration support with version navigation

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { GenerateRequest, GenerateResponse } from '../types';
+import type { GenerateRequest, GenerateResponse, IterateRequest, IterateResponse } from '../types';
 
 const api = axios.create({
   baseURL: '/api',
@@ -7,5 +7,10 @@ const api = axios.create({
 
 export async function generateModel(req: GenerateRequest): Promise<GenerateResponse> {
   const { data } = await api.post<GenerateResponse>('/generate', req);
+  return data;
+}
+
+export async function iterateModel(req: IterateRequest): Promise<IterateResponse> {
+  const { data } = await api.post<IterateResponse>('/iterate', req);
   return data;
 }

--- a/frontend/src/components/PromptPanel/ChatHistory.tsx
+++ b/frontend/src/components/PromptPanel/ChatHistory.tsx
@@ -1,14 +1,26 @@
 import { useRef, useEffect } from 'react';
 import { useAppStore } from '../../stores/appStore';
-import { Bot, User } from 'lucide-react';
+import { Bot, User, RotateCcw } from 'lucide-react';
 
 export default function ChatHistory() {
   const messages = useAppStore((s) => s.messages);
+  const currentVersion = useAppStore((s) => s.currentVersion);
+  const setModelUrl = useAppStore((s) => s.setModelUrl);
+  const setCode = useAppStore((s) => s.setCode);
+  const setCurrentVersion = useAppStore((s) => s.setCurrentVersion);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
   }, [messages]);
+
+  const handleRestore = (msg: typeof messages[0]) => {
+    if (msg.model_url && msg.code && msg.version) {
+      setModelUrl(msg.model_url);
+      setCode(msg.code);
+      setCurrentVersion(msg.version);
+    }
+  };
 
   if (messages.length === 0) {
     return (
@@ -44,9 +56,26 @@ export default function ChatHistory() {
               {msg.content}
             </p>
             {msg.role === 'assistant' && msg.model_url && (
-              <div className="mt-1.5 text-xs text-success flex items-center gap-1">
-                <div className="w-1.5 h-1.5 rounded-full bg-success" />
-                Model generated
+              <div className="mt-1.5 flex items-center gap-2">
+                <div className="text-xs text-success flex items-center gap-1">
+                  <div className="w-1.5 h-1.5 rounded-full bg-success" />
+                  Model generated
+                </div>
+                {msg.version && (
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-bg-elevated text-text-muted font-mono">
+                    v{msg.version}
+                  </span>
+                )}
+                {msg.version && msg.version !== currentVersion && (
+                  <button
+                    onClick={() => handleRestore(msg)}
+                    className="text-[10px] px-1.5 py-0.5 rounded bg-accent/10 text-accent hover:bg-accent/20 transition-colors flex items-center gap-0.5"
+                    title="Restore this version"
+                  >
+                    <RotateCcw size={9} />
+                    Restore
+                  </button>
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/components/PromptPanel/PromptInput.tsx
+++ b/frontend/src/components/PromptPanel/PromptInput.tsx
@@ -1,21 +1,23 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { Send, Loader2 } from 'lucide-react';
 import { useAppStore } from '../../stores/appStore';
-import { generateModel } from '../../api/client';
+import { generateModel, iterateModel } from '../../api/client';
 import type { ChatMessage } from '../../types';
 
 export default function PromptInput() {
   const [input, setInput] = useState('');
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const isGenerating = useAppStore((s) => s.isGenerating);
   const setGenerating = useAppStore((s) => s.setGenerating);
   const setModelUrl = useAppStore((s) => s.setModelUrl);
   const setCode = useAppStore((s) => s.setCode);
   const setProjectId = useAppStore((s) => s.setProjectId);
+  const setCurrentVersion = useAppStore((s) => s.setCurrentVersion);
   const addMessage = useAppStore((s) => s.addMessage);
   const setError = useAppStore((s) => s.setError);
   const projectId = useAppStore((s) => s.projectId);
+  const code = useAppStore((s) => s.code);
+  const messages = useAppStore((s) => s.messages);
 
   const handleSend = useCallback(async () => {
     const prompt = input.trim();
@@ -36,19 +38,37 @@ export default function PromptInput() {
     setGenerating(true);
 
     try {
-      const result = await generateModel({ prompt, project_id: projectId ?? undefined });
+      let result: { project_id: string; model_url: string; code: string; version: number };
+
+      if (projectId && code) {
+        // Iterate on existing project
+        const history = messages
+          .filter((m) => m.role === 'user')
+          .map((m) => ({ role: 'user' as const, content: m.content }));
+
+        result = await iterateModel({
+          project_id: projectId,
+          instruction: prompt,
+          current_code: code,
+          history,
+        });
+      } else {
+        // First generation
+        result = await generateModel({ prompt });
+      }
 
       setProjectId(result.project_id);
       setModelUrl(result.model_url);
       setCode(result.code);
+      setCurrentVersion(result.version);
 
-      // Add assistant message
       const assistantMsg: ChatMessage = {
         id: crypto.randomUUID(),
         role: 'assistant',
         content: 'Model generated successfully.',
         code: result.code,
         model_url: result.model_url,
+        version: result.version,
         timestamp: Date.now(),
       };
       addMessage(assistantMsg);
@@ -65,7 +85,7 @@ export default function PromptInput() {
     } finally {
       setGenerating(false);
     }
-  }, [input, isGenerating, projectId, setGenerating, setModelUrl, setCode, setProjectId, addMessage, setError]);
+  }, [input, isGenerating, projectId, code, messages, setGenerating, setModelUrl, setCode, setProjectId, setCurrentVersion, addMessage, setError]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -78,11 +98,10 @@ export default function PromptInput() {
     <div className="p-3 border-t border-border">
       <div className="flex gap-2 items-end">
         <textarea
-          ref={textareaRef}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Describe a 3D model..."
+          placeholder={projectId ? 'Describe changes to your model...' : 'Describe a 3D model...'}
           rows={2}
           disabled={isGenerating}
           className="flex-1 bg-bg-elevated border border-border rounded-lg px-3 py-2 text-xs text-text-primary placeholder-text-muted resize-none focus:outline-none focus:border-accent transition-colors disabled:opacity-50"
@@ -100,7 +119,7 @@ export default function PromptInput() {
         </button>
       </div>
       <p className="text-[10px] text-text-muted mt-1.5 px-0.5">
-        Enter to send, Shift+Enter for new line
+        {projectId ? 'Iterating on current model' : 'Enter to send, Shift+Enter for new line'}
       </p>
     </div>
   );

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -14,16 +14,31 @@ interface AppState {
   code: string;
   setCode: (code: string) => void;
 
+  // Version
+  currentVersion: number;
+  setCurrentVersion: (v: number) => void;
+
   // Chat
   messages: ChatMessage[];
   addMessage: (msg: ChatMessage) => void;
   clearMessages: () => void;
+
+  // Model info
+  modelInfo: { faces: number; vertices: number; bbox: [number, number, number] } | null;
+  setModelInfo: (info: { faces: number; vertices: number; bbox: [number, number, number] } | null) => void;
+
+  // Render mode
+  renderMode: 'shaded' | 'wireframe' | 'shaded-wireframe' | 'xray';
+  setRenderMode: (mode: 'shaded' | 'wireframe' | 'shaded-wireframe' | 'xray') => void;
 
   // UI state
   isGenerating: boolean;
   setGenerating: (v: boolean) => void;
   error: string | null;
   setError: (e: string | null) => void;
+
+  // Reset project
+  resetProject: () => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -36,12 +51,32 @@ export const useAppStore = create<AppState>((set) => ({
   code: '',
   setCode: (code) => set({ code }),
 
+  currentVersion: 0,
+  setCurrentVersion: (v) => set({ currentVersion: v }),
+
   messages: [],
   addMessage: (msg) => set((s) => ({ messages: [...s.messages, msg] })),
   clearMessages: () => set({ messages: [] }),
+
+  modelInfo: null,
+  setModelInfo: (info) => set({ modelInfo: info }),
+
+  renderMode: 'shaded',
+  setRenderMode: (mode) => set({ renderMode: mode }),
 
   isGenerating: false,
   setGenerating: (v) => set({ isGenerating: v }),
   error: null,
   setError: (e) => set({ error: e }),
+
+  resetProject: () =>
+    set({
+      projectId: null,
+      modelUrl: null,
+      code: '',
+      currentVersion: 0,
+      messages: [],
+      modelInfo: null,
+      error: null,
+    }),
 }));

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,6 +7,21 @@ export interface GenerateResponse {
   project_id: string;
   model_url: string;
   code: string;
+  version: number;
+}
+
+export interface IterateRequest {
+  project_id: string;
+  instruction: string;
+  current_code: string;
+  history?: { role: string; content: string }[];
+}
+
+export interface IterateResponse {
+  project_id: string;
+  model_url: string;
+  code: string;
+  version: number;
 }
 
 export interface ChatMessage {
@@ -15,5 +30,6 @@ export interface ChatMessage {
   content: string;
   code?: string;
   model_url?: string;
+  version?: number;
   timestamp: number;
 }


### PR DESCRIPTION
## Summary
- PromptInput detects existing project and calls `/api/iterate` instead of `/api/generate`
- Version badges (v1, v2, ...) on assistant messages in chat history
- "Restore" button on past versions to reload that model + code
- Zustand store extended with version tracking, render mode, model info
- API client gets `iterateModel()` function

## Test Plan
- [x] Second prompt calls iterate endpoint (not generate)
- [x] Version badges render on assistant messages
- [x] Restore button appears on non-current versions
- [x] TypeScript compiles cleanly

Closes #20

Generated with [Claude Code](https://claude.com/claude-code)