### PR TITLE
feat: Render mode toggle with SSAO and edge lines

### DIFF
--- a/frontend/src/components/Viewport/ModelRenderer.tsx
+++ b/frontend/src/components/Viewport/ModelRenderer.tsx
@@ -1,58 +1,126 @@
-import { useGLTF, Center } from '@react-three/drei';
-import { useEffect, useMemo } from 'react';
+import { useGLTF, Center, Edges } from '@react-three/drei';
+import { useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
+import { useAppStore } from '../../stores/appStore';
 
 interface ModelRendererProps {
   url: string;
 }
 
+const SHADED_MATERIAL = new THREE.MeshStandardMaterial({
+  color: '#b0bec5',
+  metalness: 0.6,
+  roughness: 0.35,
+  envMapIntensity: 0.8,
+});
+
+const WIREFRAME_MATERIAL = new THREE.MeshStandardMaterial({
+  color: '#6366f1',
+  wireframe: true,
+});
+
+const XRAY_MATERIAL = new THREE.MeshPhysicalMaterial({
+  color: '#6366f1',
+  metalness: 0.0,
+  roughness: 0.4,
+  transparent: true,
+  opacity: 0.25,
+  side: THREE.DoubleSide,
+  depthWrite: false,
+});
+
+function getMaterial(mode: string): THREE.Material {
+  switch (mode) {
+    case 'wireframe':
+      return WIREFRAME_MATERIAL;
+    case 'xray':
+      return XRAY_MATERIAL;
+    default:
+      return SHADED_MATERIAL;
+  }
+}
+
 export default function ModelRenderer({ url }: ModelRendererProps) {
   const { scene } = useGLTF(url);
+  const renderMode = useAppStore((s) => s.renderMode);
+  const setModelInfo = useAppStore((s) => s.setModelInfo);
+  const groupRef = useRef<THREE.Group>(null);
 
-  const cloned = useMemo(() => {
-    const clone = scene.clone(true);
+  const meshes = useMemo(() => {
+    const result: { geometry: THREE.BufferGeometry; matrix: THREE.Matrix4 }[] = [];
+    let totalFaces = 0;
+    let totalVertices = 0;
 
-    // Apply premium PBR material to all meshes
-    const material = new THREE.MeshStandardMaterial({
-      color: '#b0bec5',
-      metalness: 0.6,
-      roughness: 0.35,
-      envMapIntensity: 0.8,
-    });
-
-    clone.traverse((child) => {
+    scene.traverse((child) => {
       if (child instanceof THREE.Mesh) {
-        child.material = material;
-        child.castShadow = true;
-        child.receiveShadow = true;
-
-        // Compute smooth normals if not present
-        if (!child.geometry.attributes.normal) {
-          child.geometry.computeVertexNormals();
+        const geo = child.geometry.clone();
+        if (!geo.attributes.normal) {
+          geo.computeVertexNormals();
         }
+        // Get world matrix
+        child.updateWorldMatrix(true, false);
+        result.push({ geometry: geo, matrix: child.matrixWorld.clone() });
+
+        totalFaces += geo.index ? geo.index.count / 3 : geo.attributes.position.count / 3;
+        totalVertices += geo.attributes.position.count;
       }
     });
 
-    return clone;
-  }, [scene]);
+    // Compute bounding box
+    const box = new THREE.Box3();
+    result.forEach(({ geometry, matrix }) => {
+      geometry.applyMatrix4(matrix);
+      geometry.computeBoundingBox();
+      if (geometry.boundingBox) {
+        box.union(geometry.boundingBox);
+      }
+    });
+
+    const size = new THREE.Vector3();
+    if (!box.isEmpty()) {
+      box.getSize(size);
+    }
+
+    // Set model info in store (deferred to avoid render-during-render)
+    setTimeout(() => {
+      setModelInfo({
+        faces: Math.round(totalFaces),
+        vertices: totalVertices,
+        bbox: [
+          Math.round(size.x * 10) / 10,
+          Math.round(size.y * 10) / 10,
+          Math.round(size.z * 10) / 10,
+        ],
+      });
+    }, 0);
+
+    return result;
+  }, [scene, setModelInfo]);
 
   useEffect(() => {
     return () => {
-      // Cleanup on unmount
-      cloned.traverse((child) => {
-        if (child instanceof THREE.Mesh) {
-          child.geometry.dispose();
-          if (child.material instanceof THREE.Material) {
-            child.material.dispose();
-          }
-        }
-      });
+      meshes.forEach(({ geometry }) => geometry.dispose());
     };
-  }, [cloned]);
+  }, [meshes]);
+
+  const material = getMaterial(renderMode);
+  const showEdges = renderMode === 'shaded-wireframe' || renderMode === 'xray';
 
   return (
     <Center>
-      <primitive object={cloned} />
+      <group ref={groupRef}>
+        {meshes.map(({ geometry }, i) => (
+          <mesh key={i} geometry={geometry} material={material} castShadow receiveShadow>
+            {showEdges && (
+              <Edges
+                threshold={15}
+                color={renderMode === 'xray' ? '#818cf8' : '#000000'}
+                lineWidth={0.5}
+              />
+            )}
+          </mesh>
+        ))}
+      </group>
     </Center>
   );
 }

--- a/frontend/src/components/Viewport/RenderModeToolbar.tsx
+++ b/frontend/src/components/Viewport/RenderModeToolbar.tsx
@@ -1,0 +1,33 @@
+import { Box, Grid3x3, Layers, Eye } from 'lucide-react';
+import { useAppStore } from '../../stores/appStore';
+
+const modes = [
+  { id: 'shaded' as const, icon: Box, label: 'Shaded' },
+  { id: 'wireframe' as const, icon: Grid3x3, label: 'Wireframe' },
+  { id: 'shaded-wireframe' as const, icon: Layers, label: 'Shaded + Edges' },
+  { id: 'xray' as const, icon: Eye, label: 'X-Ray' },
+];
+
+export default function RenderModeToolbar() {
+  const renderMode = useAppStore((s) => s.renderMode);
+  const setRenderMode = useAppStore((s) => s.setRenderMode);
+
+  return (
+    <div className="absolute top-3 left-3 flex gap-0.5 bg-bg-panel/90 backdrop-blur-sm rounded-lg border border-border p-0.5 z-10">
+      {modes.map(({ id, icon: Icon, label }) => (
+        <button
+          key={id}
+          onClick={() => setRenderMode(id)}
+          title={label}
+          className={`p-1.5 rounded-md transition-colors ${
+            renderMode === id
+              ? 'bg-accent text-white'
+              : 'text-text-muted hover:text-text-primary hover:bg-bg-elevated'
+          }`}
+        >
+          <Icon size={14} />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/Viewport/Viewport.tsx
+++ b/frontend/src/components/Viewport/Viewport.tsx
@@ -1,10 +1,13 @@
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls, Environment } from '@react-three/drei';
+import { EffectComposer, SSAO, Bloom } from '@react-three/postprocessing';
+import { BlendFunction } from 'postprocessing';
 import { Suspense } from 'react';
 import SceneSetup from './SceneSetup';
 import InfiniteGrid from './InfiniteGrid';
 import ModelRenderer from './ModelRenderer';
 import ViewCube from './ViewCube';
+import RenderModeToolbar from './RenderModeToolbar';
 import { useAppStore } from '../../stores/appStore';
 
 function LoadingFallback() {
@@ -16,40 +19,69 @@ function LoadingFallback() {
   );
 }
 
+function PostProcessing() {
+  const renderMode = useAppStore((s) => s.renderMode);
+
+  // Only apply SSAO in shaded modes
+  if (renderMode === 'wireframe') return null;
+
+  return (
+    <EffectComposer>
+      <SSAO
+        blendFunction={BlendFunction.MULTIPLY}
+        samples={16}
+        radius={0.1}
+        intensity={15}
+      />
+      <Bloom
+        intensity={0.05}
+        luminanceThreshold={0.9}
+        luminanceSmoothing={0.9}
+      />
+    </EffectComposer>
+  );
+}
+
 export default function Viewport() {
   const modelUrl = useAppStore((s) => s.modelUrl);
 
   return (
-    <Canvas
-      shadows
-      camera={{ position: [6, 4, 8], fov: 45, near: 0.1, far: 1000 }}
-      gl={{
-        antialias: true,
-        toneMapping: 3, // ACESFilmicToneMapping
-        toneMappingExposure: 1.1,
-      }}
-      style={{ background: '#13131f' }}
-    >
-      <SceneSetup />
+    <div className="relative w-full h-full">
+      <RenderModeToolbar />
 
-      <Environment preset="studio" environmentIntensity={0.4} />
+      <Canvas
+        shadows
+        camera={{ position: [6, 4, 8], fov: 45, near: 0.1, far: 1000 }}
+        gl={{
+          antialias: true,
+          toneMapping: 3, // ACESFilmicToneMapping
+          toneMappingExposure: 1.1,
+        }}
+        style={{ background: '#13131f' }}
+      >
+        <SceneSetup />
 
-      <InfiniteGrid />
+        <Environment preset="studio" environmentIntensity={0.4} />
 
-      <Suspense fallback={<LoadingFallback />}>
-        {modelUrl && <ModelRenderer url={modelUrl} />}
-      </Suspense>
+        <InfiniteGrid />
 
-      <OrbitControls
-        makeDefault
-        enableDamping
-        dampingFactor={0.08}
-        minDistance={1}
-        maxDistance={200}
-        target={[0, 0, 0]}
-      />
+        <Suspense fallback={<LoadingFallback />}>
+          {modelUrl && <ModelRenderer url={modelUrl} />}
+        </Suspense>
 
-      <ViewCube />
-    </Canvas>
+        <PostProcessing />
+
+        <OrbitControls
+          makeDefault
+          enableDamping
+          dampingFactor={0.08}
+          minDistance={1}
+          maxDistance={200}
+          target={[0, 0, 0]}
+        />
+
+        <ViewCube />
+      </Canvas>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Four render modes: Shaded / Wireframe / Shaded+Edges / X-Ray
- RenderModeToolbar overlay with toggle buttons (top-left of viewport)
- SSAO post-processing for depth perception in shaded modes
- Subtle bloom on bright surfaces
- Edge lines via drei `Edges` component
- Model info (faces, vertices, bounding box) computed from geometry

## Test Plan
- [x] All four render modes change model appearance
- [x] SSAO activates in shaded/shaded+edges/xray modes
- [x] Edge lines render on shaded-wireframe and x-ray modes
- [x] TypeScript compiles and production build passes

Closes #21

Generated with [Claude Code](https://claude.com/claude-code)