### PR TITLE
feat: /api/manual and /api/code/run endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from backend.config import settings
-from backend.routers import generate, iterate
+from backend.routers import generate, iterate, manual, code_run
 
 app = FastAPI(title="GPTCAD", version="0.1.0")
 
@@ -24,6 +24,8 @@ app.mount("/storage", StaticFiles(directory=str(settings.STORAGE_DIR)), name="st
 
 app.include_router(generate.router)
 app.include_router(iterate.router)
+app.include_router(manual.router)
+app.include_router(code_run.router)
 
 
 @app.get("/api/health")

--- a/backend/routers/code_run.py
+++ b/backend/routers/code_run.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.services.freecad_runner import execute_freecad_script
+from backend.services.mesh_converter import convert_brep_to_glb
+from backend.services.project_manager import create_project, get_next_version, save_version
+
+router = APIRouter(prefix="/api", tags=["code"])
+
+
+class CodeRunRequest(BaseModel):
+    code: str
+    project_id: str | None = None
+
+
+class CodeRunResponse(BaseModel):
+    project_id: str
+    model_url: str
+    code: str
+    version: int
+
+
+@router.post("/code/run", response_model=CodeRunResponse)
+async def run_code(req: CodeRunRequest):
+    """Execute user-edited FreeCAD Python code directly."""
+    try:
+        # Set up project
+        project_id, project_dir = create_project(req.project_id)
+
+        # Execute user code
+        brep_path = await execute_freecad_script(req.code, project_dir)
+
+        # Convert
+        glb_path = project_dir / "model.glb"
+        await convert_brep_to_glb(brep_path, glb_path)
+
+        # Save version
+        version = get_next_version(project_id)
+        model_url = f"/storage/{project_id}/model.glb"
+        save_version(project_id, version, req.code, model_url)
+        (project_dir / "code.py").write_text(req.code)
+
+        return CodeRunResponse(
+            project_id=project_id,
+            model_url=model_url,
+            code=req.code,
+            version=version,
+        )
+
+    except RuntimeError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Code execution failed: {e}")

--- a/backend/routers/manual.py
+++ b/backend/routers/manual.py
@@ -1,0 +1,67 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from backend.services.manual_codegen import generate_manual_code
+from backend.services.freecad_runner import execute_freecad_script
+from backend.services.mesh_converter import convert_brep_to_glb
+from backend.services.project_manager import create_project, get_next_version, save_version
+
+router = APIRouter(prefix="/api", tags=["manual"])
+
+
+class ManualRequest(BaseModel):
+    operation: str  # e.g. "box", "cylinder", "union", "move"
+    category: str  # "primitive", "boolean", "transform"
+    params: dict  # operation-specific parameters
+    project_id: str | None = None
+    existing_code: str | None = None
+
+
+class ManualResponse(BaseModel):
+    project_id: str
+    model_url: str
+    code: str
+    version: int
+
+
+@router.post("/manual", response_model=ManualResponse)
+async def manual_operation(req: ManualRequest):
+    """Execute a manual modeling operation."""
+    try:
+        # Generate FreeCAD code from structured operation
+        code = generate_manual_code(
+            operation=req.operation,
+            category=req.category,
+            params=req.params,
+            existing_code=req.existing_code,
+        )
+
+        # Set up project
+        project_id, project_dir = create_project(req.project_id)
+
+        # Execute
+        brep_path = await execute_freecad_script(code, project_dir)
+
+        # Convert
+        glb_path = project_dir / "model.glb"
+        await convert_brep_to_glb(brep_path, glb_path)
+
+        # Save version
+        version = get_next_version(project_id)
+        model_url = f"/storage/{project_id}/model.glb"
+        save_version(project_id, version, code, model_url)
+        (project_dir / "code.py").write_text(code)
+
+        return ManualResponse(
+            project_id=project_id,
+            model_url=model_url,
+            code=code,
+            version=version,
+        )
+
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Manual operation failed: {e}")

--- a/backend/services/manual_codegen.py
+++ b/backend/services/manual_codegen.py
@@ -1,0 +1,152 @@
+"""Generate FreeCAD Python code for manual modeling operations."""
+
+
+def _preamble(existing_code: str | None) -> str:
+    if existing_code:
+        return existing_code.rstrip() + "\n\n"
+    return (
+        'import FreeCAD, Part\n'
+        'doc = FreeCAD.newDocument("GPTCAD")\n\n'
+    )
+
+
+def _export_block() -> str:
+    return (
+        '\n# Export result\n'
+        'obj = doc.addObject("Part::Feature", "Result")\n'
+        'obj.Shape = result_shape\n'
+        'doc.recompute()\n'
+        'Part.export([obj], OUTPUT_PATH)\n'
+    )
+
+
+def generate_primitive(op: str, params: dict, existing_code: str | None = None) -> str:
+    """Generate code for a primitive shape operation."""
+    code = _preamble(existing_code)
+
+    if op == "box":
+        w = params.get("width", 10)
+        h = params.get("height", 10)
+        d = params.get("depth", 10)
+        code += f"# Create box {w} x {h} x {d} mm\n"
+        code += f"result_shape = Part.makeBox({w}, {h}, {d})\n"
+
+    elif op == "cylinder":
+        r = params.get("radius", 5)
+        h = params.get("height", 10)
+        code += f"# Create cylinder r={r} h={h} mm\n"
+        code += f"result_shape = Part.makeCylinder({r}, {h})\n"
+
+    elif op == "sphere":
+        r = params.get("radius", 5)
+        code += f"# Create sphere r={r} mm\n"
+        code += f"result_shape = Part.makeSphere({r})\n"
+
+    elif op == "cone":
+        r1 = params.get("radius1", 5)
+        r2 = params.get("radius2", 0)
+        h = params.get("height", 10)
+        code += f"# Create cone r1={r1} r2={r2} h={h} mm\n"
+        code += f"result_shape = Part.makeCone({r1}, {r2}, {h})\n"
+
+    elif op == "torus":
+        r1 = params.get("major_radius", 10)
+        r2 = params.get("minor_radius", 3)
+        code += f"# Create torus R={r1} r={r2} mm\n"
+        code += f"result_shape = Part.makeTorus({r1}, {r2})\n"
+
+    else:
+        raise ValueError(f"Unknown primitive: {op}")
+
+    code += _export_block()
+    return code
+
+
+def generate_boolean(op: str, params: dict, existing_code: str) -> str:
+    """Generate code for a boolean operation appended to existing code."""
+    # We need to add a second shape and boolean it with the result
+    tool_type = params.get("tool_type", "box")
+    tool_params = params.get("tool_params", {})
+
+    code = existing_code.rstrip() + "\n\n"
+    code += f"# Boolean {op}\n"
+    code += f"existing_shape = result_shape\n"
+
+    # Generate tool shape
+    if tool_type == "box":
+        w = tool_params.get("width", 10)
+        h = tool_params.get("height", 10)
+        d = tool_params.get("depth", 10)
+        x = tool_params.get("x", 0)
+        y = tool_params.get("y", 0)
+        z = tool_params.get("z", 0)
+        code += f"tool_shape = Part.makeBox({w}, {h}, {d}, FreeCAD.Vector({x}, {y}, {z}))\n"
+    elif tool_type == "cylinder":
+        r = tool_params.get("radius", 5)
+        ht = tool_params.get("height", 20)
+        x = tool_params.get("x", 0)
+        y = tool_params.get("y", 0)
+        z = tool_params.get("z", 0)
+        code += f"tool_shape = Part.makeCylinder({r}, {ht}, FreeCAD.Vector({x}, {y}, {z}))\n"
+    else:
+        code += f"tool_shape = Part.makeSphere(5)\n"
+
+    if op == "union":
+        code += "result_shape = existing_shape.fuse(tool_shape)\n"
+    elif op == "cut":
+        code += "result_shape = existing_shape.cut(tool_shape)\n"
+    elif op == "intersect":
+        code += "result_shape = existing_shape.common(tool_shape)\n"
+
+    code += _export_block()
+    return code
+
+
+def generate_transform(op: str, params: dict, existing_code: str) -> str:
+    """Generate code for a transform operation on existing shape."""
+    code = existing_code.rstrip() + "\n\n"
+
+    if op == "move":
+        x = params.get("x", 0)
+        y = params.get("y", 0)
+        z = params.get("z", 0)
+        code += f"# Move by ({x}, {y}, {z})\n"
+        code += f"result_shape = result_shape.translated(FreeCAD.Vector({x}, {y}, {z}))\n"
+
+    elif op == "rotate":
+        axis = params.get("axis", "z")
+        angle = params.get("angle", 45)
+        axis_map = {"x": "(1,0,0)", "y": "(0,1,0)", "z": "(0,0,1)"}
+        axis_vec = axis_map.get(axis, "(0,0,1)")
+        code += f"# Rotate {angle} deg around {axis}\n"
+        code += f"import math\n"
+        code += f"result_shape = result_shape.rotated(FreeCAD.Vector(0,0,0), FreeCAD.Vector{axis_vec}, {angle})\n"
+
+    elif op == "mirror":
+        plane = params.get("plane", "xy")
+        plane_map = {
+            "xy": "FreeCAD.Vector(0,0,0), FreeCAD.Vector(0,0,1)",
+            "xz": "FreeCAD.Vector(0,0,0), FreeCAD.Vector(0,1,0)",
+            "yz": "FreeCAD.Vector(0,0,0), FreeCAD.Vector(1,0,0)",
+        }
+        code += f"# Mirror across {plane} plane\n"
+        code += f"result_shape = result_shape.mirror({plane_map.get(plane, plane_map['xy'])})\n"
+
+    code += _export_block()
+    return code
+
+
+def generate_manual_code(operation: str, category: str, params: dict, existing_code: str | None = None) -> str:
+    """Main entry point: route to the correct generator."""
+    if category == "primitive":
+        return generate_primitive(operation, params, existing_code)
+    elif category == "boolean":
+        if not existing_code:
+            raise ValueError("Boolean operations require existing code")
+        return generate_boolean(operation, params, existing_code)
+    elif category == "transform":
+        if not existing_code:
+            raise ValueError("Transform operations require existing code")
+        return generate_transform(operation, params, existing_code)
+    else:
+        raise ValueError(f"Unknown category: {category}")


### PR DESCRIPTION
## Summary
- `POST /api/manual` — structured manual operations with auto-generated FreeCAD code
  - Primitives: box, cylinder, sphere, cone, torus
  - Booleans: union, cut, intersect (with tool shape params)
  - Transforms: move, rotate, mirror
- `POST /api/code/run` — execute user-edited FreeCAD Python code directly
- `manual_codegen.py` — code generation templates for all operation types
- Both endpoints save versions and return model URL + code

## Test Plan
- [x] All imports resolve cleanly
- [x] Both routers registered in main.py
- [x] Manual codegen produces valid FreeCAD Python for each operation type

Closes #27

Generated with [Claude Code](https://claude.com/claude-code)