### PR TITLE
feat: multi-format export endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from backend.config import settings
-from backend.routers import generate, iterate, manual, code_run, projects
+from backend.routers import generate, iterate, manual, code_run, projects, export
 
 app = FastAPI(title="GPTCAD", version="0.1.0")
 
@@ -27,6 +27,7 @@ app.include_router(iterate.router)
 app.include_router(manual.router)
 app.include_router(code_run.router)
 app.include_router(projects.router)
+app.include_router(export.router)
 
 
 @app.get("/api/health")

--- a/backend/routers/export.py
+++ b/backend/routers/export.py
@@ -1,0 +1,81 @@
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import FileResponse
+
+from backend.services.project_manager import get_project_dir
+from backend.services.exporter import export_to_format
+
+router = APIRouter(prefix="/api", tags=["export"])
+
+SUPPORTED_FORMATS = {"step", "stl", "obj", "glb", "py"}
+
+MIME_TYPES = {
+    "step": "application/step",
+    "stl": "application/sla",
+    "obj": "text/plain",
+    "glb": "model/gltf-binary",
+    "py": "text/x-python",
+}
+
+EXTENSIONS = {
+    "step": ".step",
+    "stl": ".stl",
+    "obj": ".obj",
+    "glb": ".glb",
+    "py": ".py",
+}
+
+
+@router.get("/export/{project_id}")
+async def export_model(project_id: str, format: str = Query("glb")):
+    """Export a project's model in the requested format."""
+    fmt = format.lower()
+    if fmt not in SUPPORTED_FORMATS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported format '{fmt}'. Supported: {', '.join(sorted(SUPPORTED_FORMATS))}",
+        )
+
+    try:
+        project_dir = get_project_dir(project_id)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    # For .py, return the code file
+    if fmt == "py":
+        code_path = project_dir / "code.py"
+        if not code_path.exists():
+            raise HTTPException(status_code=404, detail="No code found for this project")
+        return FileResponse(
+            path=str(code_path),
+            media_type=MIME_TYPES["py"],
+            filename=f"{project_id}{EXTENSIONS['py']}",
+        )
+
+    # For .glb, return existing file
+    if fmt == "glb":
+        glb_path = project_dir / "model.glb"
+        if not glb_path.exists():
+            raise HTTPException(status_code=404, detail="No model found for this project")
+        return FileResponse(
+            path=str(glb_path),
+            media_type=MIME_TYPES["glb"],
+            filename=f"{project_id}{EXTENSIONS['glb']}",
+        )
+
+    # For step/stl/obj, convert from .brep
+    brep_path = project_dir / "model.brep"
+    if not brep_path.exists():
+        raise HTTPException(status_code=404, detail="No model data found for this project")
+
+    output_path = project_dir / f"export{EXTENSIONS[fmt]}"
+
+    try:
+        await export_to_format(brep_path, output_path, fmt)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Export failed: {e}")
+
+    return FileResponse(
+        path=str(output_path),
+        media_type=MIME_TYPES[fmt],
+        filename=f"{project_id}{EXTENSIONS[fmt]}",
+    )

--- a/backend/services/exporter.py
+++ b/backend/services/exporter.py
@@ -1,0 +1,91 @@
+"""Export CAD models to various formats using FreeCAD subprocess."""
+
+import asyncio
+from pathlib import Path
+
+from backend.config import settings
+
+
+async def export_to_format(brep_path: Path, output_path: Path, fmt: str) -> Path:
+    """Convert a .brep file to the requested format.
+
+    Supported formats: step, stl, obj
+    """
+    script = f'''
+import sys
+import FreeCAD
+import Part
+
+try:
+    shape = Part.read(r"{brep_path}")
+'''
+
+    if fmt == "step":
+        script += f'    shape.exportStep(r"{output_path}")\n'
+    elif fmt == "stl":
+        script += f'''
+    import MeshPart, Mesh
+    try:
+        mesh_data = MeshPart.meshFromShape(
+            Shape=shape,
+            LinearDeflection=0.1,
+            AngularDeflection=0.5,
+            Relative=False
+        )
+        mesh_data.write(r"{output_path}")
+    except Exception:
+        doc = FreeCAD.newDocument("Export")
+        obj = doc.addObject("Part::Feature", "Shape")
+        obj.Shape = shape
+        doc.recompute()
+        Mesh.export([obj], r"{output_path}")
+'''
+    elif fmt == "obj":
+        script += f'''
+    import MeshPart, Mesh
+    try:
+        mesh_data = MeshPart.meshFromShape(
+            Shape=shape,
+            LinearDeflection=0.1,
+            AngularDeflection=0.5,
+            Relative=False
+        )
+        mesh_data.write(r"{output_path}")
+    except Exception:
+        doc = FreeCAD.newDocument("Export")
+        obj = doc.addObject("Part::Feature", "Shape")
+        obj.Shape = shape
+        doc.recompute()
+        Mesh.export([obj], r"{output_path}")
+'''
+    else:
+        raise ValueError(f"Unsupported export format: {fmt}")
+
+    script += '''
+    print("EXPORT_OK")
+except Exception as e:
+    print(f"EXPORT_FAILED: {e}", file=sys.stderr)
+    sys.exit(1)
+'''
+
+    script_path = brep_path.parent / f"export_{fmt}.py"
+    script_path.write_text(script)
+
+    process = await asyncio.create_subprocess_exec(
+        settings.FREECAD_CMD,
+        str(script_path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+
+    # Cleanup script
+    script_path.unlink(missing_ok=True)
+
+    if not output_path.exists():
+        raise RuntimeError(
+            f"Export to {fmt} failed.\nstdout: {stdout.decode().strip()}\nstderr: {stderr.decode().strip()}"
+        )
+
+    return output_path


### PR DESCRIPTION
## Summary
- Add `GET /api/export/{project_id}?format=step|stl|obj|glb|py` endpoint
- FreeCAD subprocess converts `.brep` to STEP, STL, OBJ formats
- GLB and Python code returned directly from existing project files
- Returns `FileResponse` for direct browser download

Closes #34

## Test plan
- [ ] `?format=glb` returns existing model.glb
- [ ] `?format=py` returns code.py
- [ ] `?format=step` converts .brep to STEP via FreeCAD
- [ ] `?format=stl` converts .brep to STL via FreeCAD
- [ ] `?format=obj` converts .brep to OBJ via FreeCAD
- [ ] Invalid format returns 400 error
- [ ] Missing project returns 404

Generated with [Claude Code](https://claude.com/claude-code)