### PR TITLE
feat: project management UI and export dropdown

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,6 +4,8 @@ import type {
   IterateRequest, IterateResponse,
   ManualRequest, ManualResponse,
   CodeRunRequest, CodeRunResponse,
+  ProjectSummary, ProjectDetail,
+  ExportFormat,
 } from '../types';
 
 const api = axios.create({
@@ -28,4 +30,34 @@ export async function manualOperation(req: ManualRequest): Promise<ManualRespons
 export async function runCode(req: CodeRunRequest): Promise<CodeRunResponse> {
   const { data } = await api.post<CodeRunResponse>('/code/run', req);
   return data;
+}
+
+// Project management
+export async function listProjects(): Promise<ProjectSummary[]> {
+  const { data } = await api.get<ProjectSummary[]>('/projects');
+  return data;
+}
+
+export async function getProject(projectId: string): Promise<ProjectDetail> {
+  const { data } = await api.get<ProjectDetail>(`/projects/${projectId}`);
+  return data;
+}
+
+export async function createProject(name?: string): Promise<ProjectSummary> {
+  const { data } = await api.post<ProjectSummary>('/projects', { name });
+  return data;
+}
+
+export async function renameProject(projectId: string, name: string): Promise<ProjectSummary> {
+  const { data } = await api.patch<ProjectSummary>(`/projects/${projectId}`, { name });
+  return data;
+}
+
+export async function deleteProject(projectId: string): Promise<void> {
+  await api.delete(`/projects/${projectId}`);
+}
+
+// Export
+export function getExportUrl(projectId: string, format: ExportFormat): string {
+  return `/api/export/${projectId}?format=${format}`;
 }

--- a/frontend/src/components/Toolbar/ExportMenu.tsx
+++ b/frontend/src/components/Toolbar/ExportMenu.tsx
@@ -1,0 +1,82 @@
+import { useState, useRef, useEffect } from 'react';
+import { Download, FileCode, Box, FileText } from 'lucide-react';
+import { useAppStore } from '../../stores/appStore';
+import { getExportUrl } from '../../api/client';
+import type { ExportFormat } from '../../types';
+
+interface FormatOption {
+  format: ExportFormat;
+  label: string;
+  description: string;
+  icon: React.ComponentType<{ size?: number }>;
+}
+
+const FORMATS: FormatOption[] = [
+  { format: 'step', label: 'STEP', description: 'CAD interchange', icon: Box },
+  { format: 'stl', label: 'STL', description: '3D printing', icon: Box },
+  { format: 'obj', label: 'OBJ', description: 'Mesh with materials', icon: Box },
+  { format: 'glb', label: 'GLB', description: 'Web 3D format', icon: Box },
+  { format: 'py', label: 'Python', description: 'FreeCAD script', icon: FileCode },
+];
+
+export default function ExportMenu() {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const projectId = useAppStore((s) => s.projectId);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    if (open) document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const handleExport = (format: ExportFormat) => {
+    if (!projectId) return;
+    const url = getExportUrl(projectId, format);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = '';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        onClick={() => setOpen(!open)}
+        disabled={!projectId}
+        className="p-2 rounded-md hover:bg-bg-elevated text-text-secondary hover:text-text-primary transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+        title="Export model"
+      >
+        <Download size={16} />
+      </button>
+
+      {open && projectId && (
+        <div className="absolute right-0 top-full mt-1 bg-bg-panel border border-border rounded-lg shadow-xl py-1 z-50 min-w-[180px]">
+          <div className="px-3 py-1.5 text-[10px] text-text-muted uppercase tracking-wider font-medium">
+            Export As
+          </div>
+          {FORMATS.map((opt) => (
+            <button
+              key={opt.format}
+              onClick={() => handleExport(opt.format)}
+              className="w-full flex items-center gap-2.5 px-3 py-2 text-left hover:bg-bg-elevated transition-colors"
+            >
+              <opt.icon size={14} className="text-text-muted shrink-0" />
+              <div>
+                <div className="text-xs text-text-primary font-medium">{opt.label}</div>
+                <div className="text-[10px] text-text-muted">{opt.description}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Toolbar/ProjectListModal.tsx
+++ b/frontend/src/components/Toolbar/ProjectListModal.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react';
+import { X, Trash2, Loader2, FolderOpen, Plus } from 'lucide-react';
+import { listProjects, getProject, deleteProject } from '../../api/client';
+import { useAppStore } from '../../stores/appStore';
+import type { ProjectSummary } from '../../types';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function ProjectListModal({ open, onClose }: Props) {
+  const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const setProjectId = useAppStore((s) => s.setProjectId);
+  const setProjectName = useAppStore((s) => s.setProjectName);
+  const setModelUrl = useAppStore((s) => s.setModelUrl);
+  const setCode = useAppStore((s) => s.setCode);
+  const setCurrentVersion = useAppStore((s) => s.setCurrentVersion);
+  const resetProject = useAppStore((s) => s.resetProject);
+
+  useEffect(() => {
+    if (open) {
+      setLoading(true);
+      listProjects()
+        .then(setProjects)
+        .catch(() => {})
+        .finally(() => setLoading(false));
+    }
+  }, [open]);
+
+  const handleOpen = async (project: ProjectSummary) => {
+    try {
+      const detail = await getProject(project.id);
+      setProjectId(detail.id);
+      setProjectName(detail.name);
+
+      // Load the latest version
+      if (detail.versions.length > 0) {
+        const latest = detail.versions[detail.versions.length - 1];
+        setModelUrl(latest.model_url);
+        setCode(latest.code || '');
+        setCurrentVersion(latest.version);
+      }
+      onClose();
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setDeletingId(id);
+    try {
+      await deleteProject(id);
+      setProjects((prev) => prev.filter((p) => p.id !== id));
+    } catch {
+      // ignore
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleNew = () => {
+    resetProject();
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} />
+
+      {/* Modal */}
+      <div className="relative bg-bg-panel border border-border rounded-xl shadow-2xl w-full max-w-md max-h-[70vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
+          <div className="flex items-center gap-2">
+            <FolderOpen size={16} className="text-accent" />
+            <span className="text-sm font-medium text-text-primary">Projects</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={handleNew}
+              className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-accent hover:bg-bg-elevated rounded-md transition-colors"
+            >
+              <Plus size={12} />
+              New
+            </button>
+            <button
+              onClick={onClose}
+              className="p-1 rounded hover:bg-bg-elevated text-text-muted"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto min-h-0 p-2">
+          {loading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 size={20} className="animate-spin text-text-muted" />
+            </div>
+          ) : projects.length === 0 ? (
+            <div className="text-center py-8 text-text-muted text-xs">
+              No projects yet. Create one by submitting a prompt.
+            </div>
+          ) : (
+            <div className="space-y-1">
+              {projects.map((project) => (
+                <div
+                  key={project.id}
+                  className="flex items-center gap-2 px-3 py-2.5 rounded-lg hover:bg-bg-elevated cursor-pointer group transition-colors"
+                  onClick={() => handleOpen(project)}
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm text-text-primary truncate">
+                      {project.name}
+                    </div>
+                    <div className="text-[10px] text-text-muted mt-0.5">
+                      {project.version_count} version{project.version_count !== 1 ? 's' : ''}
+                      {' · '}
+                      {new Date(project.updated_at).toLocaleDateString()}
+                    </div>
+                  </div>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDelete(project.id);
+                    }}
+                    disabled={deletingId === project.id}
+                    className="p-1 rounded text-text-muted hover:text-error opacity-0 group-hover:opacity-100 transition-all disabled:opacity-50"
+                    title="Delete project"
+                  >
+                    {deletingId === project.id ? (
+                      <Loader2 size={12} className="animate-spin" />
+                    ) : (
+                      <Trash2 size={12} />
+                    )}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Toolbar/TopBar.tsx
+++ b/frontend/src/components/Toolbar/TopBar.tsx
@@ -1,32 +1,116 @@
-import { Download, Settings, FolderOpen } from 'lucide-react';
+import { useState, useRef } from 'react';
+import { FolderOpen, Plus, Check, Pencil } from 'lucide-react';
+import { useAppStore } from '../../stores/appStore';
+import { renameProject } from '../../api/client';
+import ExportMenu from './ExportMenu';
+import ProjectListModal from './ProjectListModal';
 
 export default function TopBar() {
+  const projectId = useAppStore((s) => s.projectId);
+  const projectName = useAppStore((s) => s.projectName);
+  const setProjectName = useAppStore((s) => s.setProjectName);
+  const resetProject = useAppStore((s) => s.resetProject);
+
+  const [projectsOpen, setProjectsOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const startEditing = () => {
+    if (!projectId) return;
+    setEditValue(projectName);
+    setEditing(true);
+    setTimeout(() => inputRef.current?.select(), 0);
+  };
+
+  const finishEditing = async () => {
+    setEditing(false);
+    const trimmed = editValue.trim();
+    if (!trimmed || trimmed === projectName || !projectId) return;
+    setProjectName(trimmed);
+    try {
+      await renameProject(projectId, trimmed);
+    } catch {
+      // revert on failure
+      setProjectName(projectName);
+    }
+  };
+
   return (
-    <div className="h-12 flex items-center justify-between px-4 border-b border-border bg-bg-panel shrink-0">
-      <div className="flex items-center gap-3">
-        <div className="flex items-center gap-2">
-          <div className="w-7 h-7 rounded-md bg-accent flex items-center justify-center">
-            <span className="text-white font-bold text-xs">G</span>
+    <>
+      <div className="h-12 flex items-center justify-between px-4 border-b border-border bg-bg-panel shrink-0">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <div className="w-7 h-7 rounded-md bg-accent flex items-center justify-center">
+              <span className="text-white font-bold text-xs">G</span>
+            </div>
+            <span className="text-base font-bold tracking-tight text-text-primary">
+              GPTCAD
+            </span>
           </div>
-          <span className="text-base font-bold tracking-tight text-text-primary">
-            GPTCAD
-          </span>
+          <div className="w-px h-5 bg-border mx-1" />
+
+          {/* Editable project name */}
+          {editing ? (
+            <form
+              onSubmit={(e) => { e.preventDefault(); finishEditing(); }}
+              className="flex items-center gap-1"
+            >
+              <input
+                ref={inputRef}
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onBlur={finishEditing}
+                className="bg-bg-elevated border border-border rounded px-2 py-0.5 text-sm text-text-primary focus:outline-none focus:border-accent w-48"
+              />
+              <button
+                type="submit"
+                className="p-1 rounded hover:bg-bg-elevated text-accent"
+              >
+                <Check size={14} />
+              </button>
+            </form>
+          ) : (
+            <button
+              onClick={startEditing}
+              className="flex items-center gap-1.5 group"
+              title={projectId ? 'Click to rename' : ''}
+            >
+              <span className="text-sm text-text-secondary group-hover:text-text-primary transition-colors">
+                {projectName}
+              </span>
+              {projectId && (
+                <Pencil size={11} className="text-text-muted opacity-0 group-hover:opacity-100 transition-opacity" />
+              )}
+            </button>
+          )}
         </div>
-        <div className="w-px h-5 bg-border mx-1" />
-        <span className="text-sm text-text-secondary">Untitled Project</span>
+
+        <div className="flex items-center gap-1">
+          {/* New project */}
+          <button
+            onClick={resetProject}
+            className="p-2 rounded-md hover:bg-bg-elevated text-text-secondary hover:text-text-primary transition-colors"
+            title="New project"
+          >
+            <Plus size={16} />
+          </button>
+
+          {/* Open project list */}
+          <button
+            onClick={() => setProjectsOpen(true)}
+            className="p-2 rounded-md hover:bg-bg-elevated text-text-secondary hover:text-text-primary transition-colors"
+            title="Open project"
+          >
+            <FolderOpen size={16} />
+          </button>
+
+          {/* Export menu */}
+          <ExportMenu />
+        </div>
       </div>
 
-      <div className="flex items-center gap-1">
-        <button className="p-2 rounded-md hover:bg-bg-elevated text-text-secondary hover:text-text-primary transition-colors">
-          <FolderOpen size={16} />
-        </button>
-        <button className="p-2 rounded-md hover:bg-bg-elevated text-text-secondary hover:text-text-primary transition-colors">
-          <Download size={16} />
-        </button>
-        <button className="p-2 rounded-md hover:bg-bg-elevated text-text-secondary hover:text-text-primary transition-colors">
-          <Settings size={16} />
-        </button>
-      </div>
-    </div>
+      <ProjectListModal open={projectsOpen} onClose={() => setProjectsOpen(false)} />
+    </>
   );
 }

--- a/frontend/src/stores/appStore.ts
+++ b/frontend/src/stores/appStore.ts
@@ -4,7 +4,9 @@ import type { ChatMessage } from '../types';
 interface AppState {
   // Project
   projectId: string | null;
+  projectName: string;
   setProjectId: (id: string) => void;
+  setProjectName: (name: string) => void;
 
   // Model
   modelUrl: string | null;
@@ -44,7 +46,9 @@ interface AppState {
 
 export const useAppStore = create<AppState>((set) => ({
   projectId: null,
+  projectName: 'Untitled Project',
   setProjectId: (id) => set({ projectId: id }),
+  setProjectName: (name) => set({ projectName: name }),
 
   modelUrl: null,
   setModelUrl: (url) => set({ modelUrl: url }),
@@ -74,6 +78,7 @@ export const useAppStore = create<AppState>((set) => ({
   resetProject: () =>
     set({
       projectId: null,
+      projectName: 'Untitled Project',
       modelUrl: null,
       code: '',
       previousCode: '',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -60,3 +60,21 @@ export interface ChatMessage {
   version?: number;
   timestamp: number;
 }
+
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+  version_count: number;
+}
+
+export interface ProjectDetail {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+  versions: { version: number; model_url: string; code?: string }[];
+}
+
+export type ExportFormat = 'step' | 'stl' | 'obj' | 'glb' | 'py';


### PR DESCRIPTION
## Summary
- Add project list modal (FolderOpen button) to browse, open, and delete saved projects
- Editable project name in TopBar (click pencil to rename, persists via PATCH API)
- Export dropdown with 5 formats: STEP, STL, OBJ, GLB, Python
- New Project button (+ icon) resets all state
- `projectName` tracked in Zustand store
- API client extended with project CRUD and export URL functions

Closes #35, Closes #36

## Test plan
- [ ] Click folder icon to open project list modal
- [ ] Project list loads from API with name, version count, date
- [ ] Click a project to load it (restores code + model + version)
- [ ] Delete button removes project from list and backend
- [ ] Click "New" in modal to reset to fresh state
- [ ] Click project name in TopBar to rename (persists on blur/enter)
- [ ] Export dropdown shows 5 formats, triggers file download
- [ ] Export disabled when no project is loaded
- [ ] TypeScript compiles cleanly

Generated with [Claude Code](https://claude.com/claude-code)