### PR TITLE
fix: resolve __file__ not defined in CHATCAD addon

### DIFF
--- a/CHATCAD_addon/InitGui.py
+++ b/CHATCAD_addon/InitGui.py
@@ -1,6 +1,20 @@
 """FreeCAD GUI initialization for CHATCAD addon."""
 
 import os
+import FreeCADGui
+
+# __file__ is not always defined when FreeCAD exec()s this script,
+# so derive the addon path from the module search path instead.
+_addon_dir = os.path.dirname(os.path.abspath(__file__)) if "__file__" in dir() else ""
+if not _addon_dir:
+    # Fallback: scan sys.path for our directory
+    import sys
+    for p in sys.path:
+        if os.path.isfile(os.path.join(p, "chatcad_panel.py")):
+            _addon_dir = p
+            break
+
+_icon_path = os.path.join(_addon_dir, "resources", "icons", "chatcad.svg") if _addon_dir else ""
 
 
 class ChatCADWorkbench:
@@ -8,18 +22,17 @@ class ChatCADWorkbench:
 
     MenuText = "CHATCAD"
     ToolTip = "Generate CAD models from natural language using AI"
-    Icon = os.path.join(os.path.dirname(__file__), "resources", "icons", "chatcad.svg")
+    Icon = _icon_path
 
     def Initialize(self):
         """Called when the workbench is first activated."""
-        import FreeCADGui
         from chatcad_commands import ChatCADOpenPanel, ChatCADSettings
-
-        self.appendToolbar("CHATCAD", ["ChatCAD_OpenPanel", "ChatCAD_Settings"])
-        self.appendMenu("CHATCAD", ["ChatCAD_OpenPanel", "ChatCAD_Settings"])
 
         FreeCADGui.addCommand("ChatCAD_OpenPanel", ChatCADOpenPanel())
         FreeCADGui.addCommand("ChatCAD_Settings", ChatCADSettings())
+
+        self.appendToolbar("CHATCAD", ["ChatCAD_OpenPanel", "ChatCAD_Settings"])
+        self.appendMenu("CHATCAD", ["ChatCAD_OpenPanel", "ChatCAD_Settings"])
 
     def Activated(self):
         """Called when switching to this workbench."""

--- a/CHATCAD_addon/chatcad_commands.py
+++ b/CHATCAD_addon/chatcad_commands.py
@@ -1,6 +1,18 @@
 """FreeCAD GUI commands for CHATCAD addon."""
 
 import os
+import sys
+
+# Resolve addon directory (same logic as InitGui.py)
+_addon_dir = os.path.dirname(os.path.abspath(__file__))
+if not os.path.isfile(os.path.join(_addon_dir, "chatcad_panel.py")):
+    _addon_dir = ""
+    for p in sys.path:
+        if os.path.isfile(os.path.join(p, "chatcad_panel.py")):
+            _addon_dir = p
+            break
+
+_icon_path = os.path.join(_addon_dir, "resources", "icons", "chatcad.svg") if _addon_dir else ""
 
 
 class ChatCADOpenPanel:
@@ -8,7 +20,7 @@ class ChatCADOpenPanel:
 
     def GetResources(self):
         return {
-            "Pixmap": os.path.join(os.path.dirname(__file__), "resources", "icons", "chatcad.svg"),
+            "Pixmap": _icon_path,
             "MenuText": "Open CHATCAD Panel",
             "ToolTip": "Open the AI prompt panel to generate CAD models",
         }


### PR DESCRIPTION
## Summary
- Fix `name '__file__' is not defined` error when FreeCAD loads the addon — FreeCAD `exec()`s `InitGui.py` without `__file__` being set
- Derive addon directory from `sys.path` as fallback when `__file__` is unavailable
- Import `FreeCADGui` at module level (required for `addWorkbench()` call at bottom)
- Fix command registration order: `addCommand` before `appendToolbar`

## Test plan
- [ ] Restart FreeCAD → no error in log about `__file__`
- [ ] CHATCAD workbench appears in workbench selector with icon
- [ ] Switching to CHATCAD workbench opens the prompt panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)