### PR TITLE
fix: addon InitGui __file__ NameError

### DIFF
--- a/CHATCAD_addon/InitGui.py
+++ b/CHATCAD_addon/InitGui.py
@@ -3,15 +3,20 @@
 import os
 import FreeCADGui
 
-# __file__ is not always defined when FreeCAD exec()s this script,
-# so derive the addon path from the module search path instead.
-_addon_dir = os.path.dirname(os.path.abspath(__file__)) if "__file__" in dir() else ""
-if not _addon_dir:
-    # Fallback: scan sys.path for our directory
-    import sys
-    for p in sys.path:
-        if os.path.isfile(os.path.join(p, "chatcad_panel.py")):
-            _addon_dir = p
+import sys
+
+# __file__ is not defined when FreeCAD exec()s this script.
+# Derive the addon path from sys.path as a reliable fallback.
+try:
+    _addon_dir = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    _addon_dir = ""
+
+if not _addon_dir or not os.path.isfile(os.path.join(_addon_dir, "chatcad_panel.py")):
+    _addon_dir = ""
+    for _p in sys.path:
+        if os.path.isfile(os.path.join(_p, "chatcad_panel.py")):
+            _addon_dir = _p
             break
 
 _icon_path = os.path.join(_addon_dir, "resources", "icons", "chatcad.svg") if _addon_dir else ""


### PR DESCRIPTION
## Summary
- Replace fragile `"__file__" in dir()` check with `try/except NameError` — bulletproof under FreeCAD's `exec()` scope
- Fixes `name '_icon_path' is not defined` error on FreeCAD startup

## Test plan
- [ ] Restart FreeCAD → no error in console log
- [ ] CHATCAD workbench loads and appears in selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)