### PR TITLE
fix: move Icon assignment outside class body for exec() compat

### DIFF
--- a/CHATCAD_addon/InitGui.py
+++ b/CHATCAD_addon/InitGui.py
@@ -30,7 +30,7 @@ class ChatCADWorkbench:
 
     MenuText = "CHATCAD"
     ToolTip = "Generate CAD models from natural language using AI"
-    Icon = _find_icon()
+    Icon = ""
 
     def Initialize(self):
         """Called when the workbench is first activated."""
@@ -55,4 +55,7 @@ class ChatCADWorkbench:
         return "Gui::PythonWorkbench"
 
 
+# Set Icon AFTER class definition — inside class bodies, Python only searches
+# the class namespace + globals, skipping exec() locals where our functions live.
+ChatCADWorkbench.Icon = _find_icon()
 FreeCADGui.addWorkbench(ChatCADWorkbench())


### PR DESCRIPTION
## Summary
- FreeCAD `exec()`s `InitGui.py` with separate globals/locals dicts
- Python class bodies only search their own namespace + `globals`, **skipping** exec `locals` where `_find_icon()` is defined
- Moved `Icon = _find_icon()` from inside the class body to after the class definition, at exec's top level where locals ARE searchable

## Test plan
- [ ] Restart FreeCAD and verify CHATCAD workbench loads without errors
- [ ] Verify the workbench icon appears in the workbench selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)