### PR TITLE
fix: inherit FreeCADGui.Workbench for proper addon registration

### DIFF
--- a/CHATCAD_addon/InitGui.py
+++ b/CHATCAD_addon/InitGui.py
@@ -23,7 +23,7 @@ if not _icon:
             break
 
 
-class ChatCADWorkbench:
+class ChatCADWorkbench(FreeCADGui.Workbench):
     """CHATCAD Workbench — AI-powered CAD from natural language."""
 
     MenuText = "CHATCAD"
@@ -54,4 +54,4 @@ class ChatCADWorkbench:
 
 
 ChatCADWorkbench.Icon = _icon
-FreeCADGui.addWorkbench(ChatCADWorkbench())
+FreeCADGui.addWorkbench(ChatCADWorkbench)


### PR DESCRIPTION
## Summary
- `addWorkbench` requires a subclass (or instance of subclass) of `Workbench`
- Added explicit `FreeCADGui.Workbench` as base class
- Pass the class itself (not an instance) — standard FreeCAD addon pattern

## Test plan
- [ ] Restart FreeCAD — CHATCAD workbench loads without errors
- [ ] Workbench appears in the workbench selector with icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)